### PR TITLE
Merge post_install hooks in the Podfile

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,11 +37,7 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
-  end
-end
 
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
     if target.name == "geolocator_apple"
       target.build_configurations.each do |config|
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'BYPASS_PERMISSION_LOCATION_ALWAYS=1']


### PR DESCRIPTION
Multiple post_install hooks result in the error while executing `pod install`:
```
   [!] Invalid `Podfile` file: [!] Specifying multiple `post_install` hooks is unsupported..
```