### PR TITLE
Cleaner pinging

### DIFF
--- a/lib/infrastructure/battery_reader.dart
+++ b/lib/infrastructure/battery_reader.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
 
-import 'package:clock/clock.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -79,11 +78,11 @@ class BatteryReader {
   }
 
   Future<void> _writeSocToCache(int soc) async {
-    _lastPingController.add(clock.now());
+    _lastPingController.add(DateTime.now());
     var sharedPrefs = await _getSharedPrefs();
     await sharedPrefs.setInt(_getSocCacheKey(_battery), soc);
     await sharedPrefs.setInt(
-        lastPingCacheKey, clock.now().microsecondsSinceEpoch);
+        lastPingCacheKey, DateTime.now().microsecondsSinceEpoch);
   }
 
   String _getSocCacheKey(ScooterBattery battery) => "${battery.name}SOC";

--- a/lib/infrastructure/battery_reader.dart
+++ b/lib/infrastructure/battery_reader.dart
@@ -10,15 +10,12 @@ import 'package:unustasis/infrastructure/utils.dart';
 
 class BatteryReader {
   final ScooterBattery _battery;
-  final BehaviorSubject<DateTime?> _lastPingController;
+  final void Function() ping;
 
-  static const lastPingCacheKey = "lastPing";
-
-  BatteryReader(this._battery, this._lastPingController);
+  BatteryReader(this._battery, this.ping);
 
   readAndSubscribeSOC(BluetoothCharacteristic socCharacteristic,
       BehaviorSubject<int?> socController) async {
-    var c = Completer();
     subscribeCharacteristic(socCharacteristic, (value) async {
       int? soc;
       if (_battery == ScooterBattery.cbb) {
@@ -30,18 +27,10 @@ class BatteryReader {
       // sometimes the scooter sends null. Ignoring those values...
       if (soc != null) {
         socController.add(soc);
-        await _writeSocToCache(soc);
+        _writeSocToCache(soc);
+        ping();
       }
-      c.complete();
     });
-
-    // wait for written values
-    await c.future;
-
-    int? cachedSoc = await _readSocFromCache();
-    if (cachedSoc != null) {
-      socController.add(cachedSoc);
-    }
   }
 
   readAndSubscribeCycles(BluetoothCharacteristic cyclesCharacteristic,
@@ -50,6 +39,7 @@ class BatteryReader {
       int? cycles = _convertUint32ToInt(value);
       log("$_battery battery cycles received: $cycles");
       cyclesController.add(cycles);
+      ping();
     });
   }
 
@@ -59,46 +49,20 @@ class BatteryReader {
         .readAndSubscribe((String chargingState) {
       if (chargingState == "charging") {
         chargingController.add(true);
+        ping();
       } else if (chargingState == "not-charging") {
         chargingController.add(false);
+        ping();
       }
     });
   }
 
-  Future<int?> _readSocFromCache() async {
-    DateTime? lastPing = await _readLastPing();
-    if (lastPing == null) {
-      return null;
-    }
-
-    _lastPingController.add(lastPing);
-    var sharedPrefs = await _getSharedPrefs();
-    int? soc = sharedPrefs.getInt(_getSocCacheKey(_battery));
-    return soc;
-  }
-
   Future<void> _writeSocToCache(int soc) async {
-    _lastPingController.add(DateTime.now());
-    var sharedPrefs = await _getSharedPrefs();
+    var sharedPrefs = await SharedPreferences.getInstance();
     await sharedPrefs.setInt(_getSocCacheKey(_battery), soc);
-    await sharedPrefs.setInt(
-        lastPingCacheKey, DateTime.now().microsecondsSinceEpoch);
   }
 
   String _getSocCacheKey(ScooterBattery battery) => "${battery.name}SOC";
-
-  Future<DateTime?> _readLastPing() async {
-    var sharedPrefs = await _getSharedPrefs();
-    int? epoch = sharedPrefs.getInt(lastPingCacheKey);
-    if (epoch == null) {
-      return null;
-    }
-    return DateTime.fromMicrosecondsSinceEpoch(epoch);
-  }
-
-  Future<SharedPreferences> _getSharedPrefs() async {
-    return await SharedPreferences.getInstance();
-  }
 
   int? _convertUint32ToInt(List<int> uint32data) {
     log("Converting $uint32data to int.");

--- a/lib/infrastructure/scooter_reader.dart
+++ b/lib/infrastructure/scooter_reader.dart
@@ -15,7 +15,6 @@ class ScooterReader {
   final BehaviorSubject<ScooterState?> _stateController;
   final BehaviorSubject<bool?> _seatClosedController;
   final BehaviorSubject<bool?> _handlebarController;
-  final BehaviorSubject<DateTime?> _lastPingController;
   final BehaviorSubject<int?> _auxSOCController;
   final BehaviorSubject<int?> _cbbSOCController;
   final BehaviorSubject<bool?> _cbbChargingController;
@@ -24,31 +23,33 @@ class ScooterReader {
   final BehaviorSubject<int?> _primaryCyclesController;
   final BehaviorSubject<int?> _secondaryCyclesController;
 
+  final void Function() ping;
+
   ScooterReader(
       {required CharacteristicRepository characteristicRepository,
       required BehaviorSubject<ScooterState?> stateController,
       required BehaviorSubject<bool?> seatClosedController,
       required BehaviorSubject<bool?> handlebarController,
-      required BehaviorSubject<DateTime?> lastPingController,
       required BehaviorSubject<int?> auxSOCController,
       required BehaviorSubject<int?> cbbSOCController,
       required BehaviorSubject<bool?> cbbChargingController,
       required BehaviorSubject<int?> primarySOCController,
       required BehaviorSubject<int?> secondarySOCController,
       required BehaviorSubject<int?> primaryCyclesController,
-      required BehaviorSubject<int?> secondaryCyclesController})
+      required BehaviorSubject<int?> secondaryCyclesController,
+      required void Function() pingFunc})
       : _characteristicRepository = characteristicRepository,
         _stateController = stateController,
         _seatClosedController = seatClosedController,
         _handlebarController = handlebarController,
-        _lastPingController = lastPingController,
         _auxSOCController = auxSOCController,
         _cbbSOCController = cbbSOCController,
         _cbbChargingController = cbbChargingController,
         _primarySOCController = primarySOCController,
         _secondarySOCController = secondarySOCController,
         _primaryCyclesController = primaryCyclesController,
-        _secondaryCyclesController = secondaryCyclesController;
+        _secondaryCyclesController = secondaryCyclesController,
+        ping = pingFunc;
 
   readAndSubscribe() {
     _subscribeState();
@@ -81,6 +82,7 @@ class ScooterReader {
       ScooterState newState =
           ScooterState.fromStateAndPowerState(_state!, powerState);
       _stateController.add(newState);
+      ping();
     }
   }
 
@@ -88,6 +90,7 @@ class ScooterReader {
     StringReader("Seat", _characteristicRepository.seatCharacteristic)
         .readAndSubscribe((String seatState) {
       _seatClosedController.add(seatState != "open");
+      ping();
     });
   }
 
@@ -96,25 +99,23 @@ class ScooterReader {
             "Handlebars", _characteristicRepository.handlebarCharacteristic)
         .readAndSubscribe((String handlebarState) {
       _handlebarController.add(handlebarState != "unlocked");
+      ping();
     });
   }
 
   void _subscribeBatteries() {
-    var auxBatterReader =
-        BatteryReader(ScooterBattery.aux, _lastPingController);
+    var auxBatterReader = BatteryReader(ScooterBattery.aux, ping);
     auxBatterReader.readAndSubscribeSOC(
         _characteristicRepository.auxSOCCharacteristic, _auxSOCController);
 
-    var cbbBatterReader =
-        BatteryReader(ScooterBattery.cbb, _lastPingController);
-    cbbBatterReader.readAndSubscribeSOC(
+    var cbbBatteryReader = BatteryReader(ScooterBattery.cbb, ping);
+    cbbBatteryReader.readAndSubscribeSOC(
         _characteristicRepository.cbbSOCCharacteristic, _cbbSOCController);
-    cbbBatterReader.readAndSubscribeCharging(
+    cbbBatteryReader.readAndSubscribeCharging(
         _characteristicRepository.cbbChargingCharacteristic,
         _cbbChargingController);
 
-    var primaryBatteryReader =
-        BatteryReader(ScooterBattery.primary, _lastPingController);
+    var primaryBatteryReader = BatteryReader(ScooterBattery.primary, ping);
     primaryBatteryReader.readAndSubscribeSOC(
         _characteristicRepository.primarySOCCharacteristic,
         _primarySOCController);
@@ -122,8 +123,7 @@ class ScooterReader {
         _characteristicRepository.primaryCyclesCharacteristic,
         _primaryCyclesController);
 
-    var secondaryBatteryReader =
-        BatteryReader(ScooterBattery.secondary, _lastPingController);
+    var secondaryBatteryReader = BatteryReader(ScooterBattery.secondary, ping);
     secondaryBatteryReader.readAndSubscribeSOC(
         _characteristicRepository.secondarySOCCharacteristic,
         _secondarySOCController);

--- a/lib/stats/scooter_section.dart
+++ b/lib/stats/scooter_section.dart
@@ -283,17 +283,19 @@ class _ScooterSectionState extends State<ScooterSection> {
                     FlutterI18n.translate(context, "stats_unknown")),
               );
             }),
-        StreamBuilder<int?>(
-          stream: widget.service.rssi,
-          builder: (context, snapshot) {
-            return ListTile(
-              title: Text(FlutterI18n.translate(context, "stats_rssi")),
-              subtitle: Text(snapshot.data != null
-                  ? "${snapshot.data} dBm"
-                  : FlutterI18n.translate(context, "stats_rssi_disconnected")),
-            );
-          },
-        ),
+        if (widget.service.autoUnlock)
+          StreamBuilder<int?>(
+            stream: widget.service.rssi,
+            builder: (context, snapshot) {
+              return ListTile(
+                title: Text(FlutterI18n.translate(context, "stats_rssi")),
+                subtitle: Text(snapshot.data != null
+                    ? "${snapshot.data} dBm"
+                    : FlutterI18n.translate(
+                        context, "stats_rssi_disconnected")),
+              );
+            },
+          ),
         StreamBuilder<LatLng?>(
             stream: widget.service.lastLocation,
             builder: (context, position) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -154,7 +154,7 @@ packages:
     source: hosted
     version: "0.4.1"
   clock:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,6 @@ dependencies:
   flutter_native_splash: ^2.4.0
   easy_dynamic_theme: ^2.3.1
   shimmer: ^3.0.0
-  clock: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Removing pinging from the battery controller and giving it back to the overarching scooter service. Passing on a "ping()" function to all readers to trigger whenever they receive data.

## QA checklist

- [x] Read state (state & power state)
- [x] Read primary battery SOC
- [x] Read primary battery cycles
- [x] Read secondary battery SOC
- [x] Read secondary battery cycles
- [x] Read seat closed
- [x] Read handlebar
- [x] Read AUX SOC
- [x] Read CBB SOC
- [x] Read CBB charging state
- [x] Update ping
- [x] SOCs are cached (after app restart)
- [x] Commands can be sent (locking & hibernation)
