### PR TITLE
Disable seat button in hibernation

### DIFF
--- a/lib/domain/scooter_state.dart
+++ b/lib/domain/scooter_state.dart
@@ -170,4 +170,14 @@ extension StateExtension on ScooterState {
         return false;
     }
   }
+
+  bool get isReadyForSeatOpen {
+    switch (this) {
+      case ScooterState.hibernating:
+      case ScooterState.hibernatingImminent:
+        return false;
+      default:
+        return true;
+    }
+  }
 }

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -296,7 +296,8 @@ class _HomeScreenState extends State<HomeScreen> {
                               onPressed: _connected &&
                                       _scooterState != null &&
                                       _seatClosed == true &&
-                                      _scanning == false
+                                      _scanning == false &&
+                                      _scooterState?.isReadyForSeatOpen == true
                                   ? widget.scooterService.openSeat
                                   : null,
                               label: _seatClosed == false


### PR DESCRIPTION
Seat button is disabled when scooter is hibernating or about to hibernate
## QA checklist

- [ ] Read state (state & power state)
- [ ] Read primary battery SOC
- [ ] Read primary battery cycles
- [ ] Read secondary battery SOC
- [ ] Read secondary battery cycles
- [ ] Read seat closed
- [ ] Read handlebar
- [ ] Read AUX SOC
- [ ] Read CBB SOC
- [ ] Read CBB charging state
- [ ] Update ping
- [ ] SOCs are cached (after app restart)
- [ ] Commands can be sent (locking & hibernation)
