### PR TITLE
feat: replace multi-tab interface with direct navigation screens

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -54,6 +54,7 @@
     "state_name_unknown": "Connected",
     "state_name_disconnected": "Disconnected",
     "state_name_linking": "Connecting...",
+    "state_name_scanning": "Scanning...",
     "state_desc_standby": "Your scooter is in standby mode",
     "state_desc_off": "Your scooter is fully powered down",
     "state_desc_parked": "Your scooter is powered on and parked",

--- a/lib/battery_screen.dart
+++ b/lib/battery_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_i18n/flutter_i18n.dart';
+import 'package:provider/provider.dart';
+
+import 'scooter_service.dart';
+import 'stats/battery_section.dart';
+
+class BatteryScreen extends StatelessWidget {
+  const BatteryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(FlutterI18n.translate(context, 'stats_title_battery')),
+        backgroundColor: Theme.of(context).colorScheme.surface,
+      ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: RadialGradient(
+            center: Alignment.center,
+            radius: 1.3,
+            colors: [
+              Theme.of(context).colorScheme.surface,
+              Theme.of(context).colorScheme.surface,
+            ],
+          ),
+        ),
+        child: SafeArea(
+          child: Selector<ScooterService, DateTime?>(
+            selector: (context, service) => service.lastPing,
+            builder: (context, lastPing, _) {
+              bool dataIsOld = lastPing == null ||
+                  lastPing.difference(DateTime.now()).inMinutes.abs() > 5;
+              return BatterySection(dataIsOld: dataIsOld);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/battery_screen.dart
+++ b/lib/battery_screen.dart
@@ -26,15 +26,13 @@ class BatteryScreen extends StatelessWidget {
             ],
           ),
         ),
-        child: SafeArea(
-          child: Selector<ScooterService, DateTime?>(
-            selector: (context, service) => service.lastPing,
-            builder: (context, lastPing, _) {
-              bool dataIsOld = lastPing == null ||
-                  lastPing.difference(DateTime.now()).inMinutes.abs() > 5;
-              return BatterySection(dataIsOld: dataIsOld);
-            },
-          ),
+        child: Selector<ScooterService, DateTime?>(
+          selector: (context, service) => service.lastPing,
+          builder: (context, lastPing, _) {
+            bool dataIsOld = lastPing == null ||
+                lastPing.difference(DateTime.now()).inMinutes.abs() > 5;
+            return BatterySection(dataIsOld: dataIsOld);
+          },
         ),
       ),
     );

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -190,7 +190,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   children: [
                     Positioned(
                       top: 0,
-                      left: 0,
+                      left: 8,
                       child: IconButton(
                         icon: const Icon(Icons.help_outline),
                         onPressed: () => Navigator.push(
@@ -203,7 +203,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     ),
                     Positioned(
                       top: 0,
-                      right: 0,
+                      right: 8,
                       child: IconButton(
                         icon: const Icon(Icons.settings),
                         onPressed: () => Navigator.push(

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -23,7 +23,10 @@ import '../onboarding_screen.dart';
 import '../scooter_service.dart';
 import '../domain/scooter_state.dart';
 import '../scooter_visual.dart';
-import '../stats/stats_screen.dart';
+import '../battery_screen.dart';
+import '../scooter_screen.dart';
+import '../settings_screen.dart';
+import '../support_screen.dart';
 import '../helper_widgets/snowfall.dart';
 import '../helper_widgets/grassscape.dart';
 
@@ -183,19 +186,49 @@ class _HomeScreenState extends State<HomeScreen> {
                   child: GrassScape(),
                 ),
               SafeArea(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 40,
-                  ),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    mainAxisSize: MainAxisSize.max,
-                    children: [
+                child: Stack(
+                  children: [
+                    Positioned(
+                      top: 0,
+                      right: 0,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.settings),
+                            onPressed: () => Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => const SettingsScreen(),
+                              ),
+                            ),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.help_outline),
+                            onPressed: () => Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => const SupportScreen(),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(
+                        top: 64,
+                        bottom: 40,
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        mainAxisSize: MainAxisSize.max,
+                        children: [
                       InkWell(
                         onTap: () => Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => const StatsScreen(),
+                            builder: (context) => const ScooterScreen(),
                           ),
                         ),
                         // Hidden for stable release, but useful for various debugging
@@ -230,7 +263,29 @@ class _HomeScreenState extends State<HomeScreen> {
                       if (context.select<ScooterService, int?>(
                               (service) => service.primarySOC) !=
                           null)
-                        const BatteryBars(),
+                        GestureDetector(
+                          onTap: () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => const BatteryScreen(),
+                            ),
+                          ),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              const BatteryBars(),
+                              const SizedBox(width: 8),
+                              Icon(
+                                Icons.info_outline,
+                                size: 16,
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurface
+                                    .withValues(alpha: 0.6),
+                              ),
+                            ],
+                          ),
+                        ),
                       const SizedBox(height: 16),
                       Expanded(
                         child: ScooterVisual(
@@ -385,10 +440,12 @@ class _HomeScreenState extends State<HomeScreen> {
                               }),
                         ],
                       )
-                    ],
+                      ],
+                    ),
                   ),
-                ),
+                ],
               ),
+            ),
             ],
           ),
         ),

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -190,34 +190,33 @@ class _HomeScreenState extends State<HomeScreen> {
                   children: [
                     Positioned(
                       top: 0,
+                      left: 0,
+                      child: IconButton(
+                        icon: const Icon(Icons.help_outline),
+                        onPressed: () => Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const SupportScreen(),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      top: 0,
                       right: 0,
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          IconButton(
-                            icon: const Icon(Icons.settings),
-                            onPressed: () => Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => const SettingsScreen(),
-                              ),
-                            ),
+                      child: IconButton(
+                        icon: const Icon(Icons.settings),
+                        onPressed: () => Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const SettingsScreen(),
                           ),
-                          IconButton(
-                            icon: const Icon(Icons.help_outline),
-                            onPressed: () => Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => const SupportScreen(),
-                              ),
-                            ),
-                          ),
-                        ],
+                        ),
                       ),
                     ),
                     Padding(
                       padding: const EdgeInsets.only(
-                        top: 64,
+                        top: 40,
                         bottom: 40,
                       ),
                       child: Column(
@@ -609,6 +608,7 @@ class BatteryBars extends StatelessWidget {
           return Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
+              const SizedBox(width: 16),
               SizedBox(
                   width: MediaQuery.of(context).size.width / 6,
                   child: LinearProgressIndicator(

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -259,7 +259,9 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                       const StatusText(),
                       const SizedBox(height: 16),
-                      if (context.select<ScooterService, int?>(
+                      if (context.select<ScooterService, bool>(
+                              (service) => service.connected) &&
+                          context.select<ScooterService, int?>(
                               (service) => service.primarySOC) !=
                           null)
                         GestureDetector(

--- a/lib/scooter_screen.dart
+++ b/lib/scooter_screen.dart
@@ -26,15 +26,13 @@ class ScooterScreen extends StatelessWidget {
             ],
           ),
         ),
-        child: SafeArea(
-          child: Selector<ScooterService, DateTime?>(
-            selector: (context, service) => service.lastPing,
-            builder: (context, lastPing, _) {
-              bool dataIsOld = lastPing == null ||
-                  lastPing.difference(DateTime.now()).inMinutes.abs() > 5;
-              return ScooterSection(dataIsOld: dataIsOld);
-            },
-          ),
+        child: Selector<ScooterService, DateTime?>(
+          selector: (context, service) => service.lastPing,
+          builder: (context, lastPing, _) {
+            bool dataIsOld = lastPing == null ||
+                lastPing.difference(DateTime.now()).inMinutes.abs() > 5;
+            return ScooterSection(dataIsOld: dataIsOld);
+          },
         ),
       ),
     );

--- a/lib/scooter_screen.dart
+++ b/lib/scooter_screen.dart
@@ -9,8 +9,19 @@ import 'onboarding_screen.dart';
 class ScooterScreen extends StatelessWidget {
   const ScooterScreen({super.key});
 
+  static ScooterScreen? _currentInstance;
+  static BuildContext? _currentContext;
+
+  static void closeScreen() {
+    if (_currentContext != null && Navigator.of(_currentContext!).canPop()) {
+      Navigator.of(_currentContext!).pop();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    _currentInstance = this;
+    _currentContext = context;
     return Scaffold(
       appBar: AppBar(
         title: Text(FlutterI18n.translate(context, 'stats_title_scooter')),

--- a/lib/scooter_screen.dart
+++ b/lib/scooter_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_i18n/flutter_i18n.dart';
+import 'package:provider/provider.dart';
+
+import 'scooter_service.dart';
+import 'stats/scooter_section.dart';
+
+class ScooterScreen extends StatelessWidget {
+  const ScooterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(FlutterI18n.translate(context, 'stats_title_scooter')),
+        backgroundColor: Theme.of(context).colorScheme.surface,
+      ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: RadialGradient(
+            center: Alignment.center,
+            radius: 1.3,
+            colors: [
+              Theme.of(context).colorScheme.surface,
+              Theme.of(context).colorScheme.surface,
+            ],
+          ),
+        ),
+        child: SafeArea(
+          child: Selector<ScooterService, DateTime?>(
+            selector: (context, service) => service.lastPing,
+            builder: (context, lastPing, _) {
+              bool dataIsOld = lastPing == null ||
+                  lastPing.difference(DateTime.now()).inMinutes.abs() > 5;
+              return ScooterSection(dataIsOld: dataIsOld);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/scooter_screen.dart
+++ b/lib/scooter_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import 'scooter_service.dart';
 import 'stats/scooter_section.dart';
+import 'onboarding_screen.dart';
 
 class ScooterScreen extends StatelessWidget {
   const ScooterScreen({super.key});
@@ -14,6 +15,28 @@ class ScooterScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(FlutterI18n.translate(context, 'stats_title_scooter')),
         backgroundColor: Theme.of(context).colorScheme.surface,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () async {
+              final service = context.read<ScooterService>();
+              service.myScooter?.disconnect();
+              service.myScooter = null;
+
+              List<String> savedIds = await service.getSavedScooterIds();
+              if (context.mounted) {
+                Navigator.push(context, MaterialPageRoute(
+                  builder: (context) {
+                    return OnboardingScreen(
+                      excludedScooterIds: savedIds,
+                      skipWelcome: true,
+                    );
+                  },
+                ));
+              }
+            },
+          ),
+        ],
       ),
       body: Container(
         decoration: BoxDecoration(

--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -24,9 +24,7 @@ class SettingsScreen extends StatelessWidget {
             ],
           ),
         ),
-        child: const SafeArea(
-          child: SettingsSection(),
-        ),
+        child: const SettingsSection(),
       ),
     );
   }

--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 
-import 'stats/support_section.dart';
+import 'stats/settings_section.dart';
 
-class SupportScreen extends StatelessWidget {
-  const SupportScreen({super.key});
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(FlutterI18n.translate(context, 'stats_title_support')),
+        title: Text(FlutterI18n.translate(context, 'stats_title_settings')),
         backgroundColor: Theme.of(context).colorScheme.surface,
       ),
       body: Container(
@@ -25,7 +25,7 @@ class SupportScreen extends StatelessWidget {
           ),
         ),
         child: const SafeArea(
-          child: SupportSection(),
+          child: SettingsSection(),
         ),
       ),
     );

--- a/lib/stats/scooter_section.dart
+++ b/lib/stats/scooter_section.dart
@@ -243,99 +243,71 @@ class SavedScooterCard extends StatelessWidget {
                   },
                 ),
                 const SizedBox(height: 4),
-                Text(
-                  connected
-                      ? FlutterI18n.translate(context, "state_name_unknown")
-                      : FlutterI18n.translate(
-                          context, "state_name_disconnected"),
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 24),
                 if (connected)
-                  Divider(
-                    indent: 16,
-                    endIndent: 16,
-                    height: 0,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.1),
-                  ),
-                if (connected)
-                  ListTile(
-                    title: Text(FlutterI18n.translate(context, "stats_state")),
-                    subtitle: Text(
-                      context
-                              .select<ScooterService, ScooterState?>(
-                                  (service) => service.state)
-                              ?.description(context) ??
-                          FlutterI18n.translate(context, "stats_unknown"),
-                    ),
+                  Text(
+                    context
+                            .select<ScooterService, ScooterState?>(
+                                (service) => service.state)
+                            ?.description(context) ??
+                        FlutterI18n.translate(context, "stats_unknown"),
+                    style: Theme.of(context).textTheme.titleMedium,
                   ),
                 if (!connected)
-                  Divider(
-                    indent: 16,
-                    endIndent: 16,
-                    height: 0,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.1),
-                  ),
-                if (!connected)
-                  ListTile(
-                    title: Text(FlutterI18n.translate(
-                        context, "stats_last_ping_title")),
-                    subtitle: Text(FlutterI18n.translate(
-                        context, "stats_last_ping",
-                        translationParams: {
-                          "time": savedScooter.lastPing
-                              .calculateTimeDifferenceInShort(context)
-                              .toLowerCase()
-                        })),
-                    onTap: () {
-                      Fluttertoast.showToast(
-                          msg: savedScooter.lastPing
-                              .toString()
-                              .substring(0, 16));
-                    },
-                  ),
-                if (savedScooter.lastLocation != null && !connected)
-                  Divider(
-                    indent: 16,
-                    endIndent: 16,
-                    height: 0,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.1),
-                  ),
-                if (savedScooter.lastLocation != null && !connected)
-                  ListTile(
-                    title: Text(
-                      FlutterI18n.translate(context, "stats_last_seen_near"),
-                    ),
-                    subtitle: FutureBuilder<String?>(
-                      future: GeoHelper.getAddress(
-                          savedScooter.lastLocation!, context),
-                      builder: (context, snapshot) {
-                        if (snapshot.hasData) {
-                          return Text(snapshot.data!);
-                        } else {
-                          return Text(
-                            FlutterI18n.translate(context, "stats_no_location"),
-                          );
-                        }
-                      },
-                    ),
-                    trailing: const Icon(Icons.exit_to_app_outlined),
-                    onTap: () {
+                  InkWell(
+                    onTap: savedScooter.lastLocation != null ? () {
                       MapsLauncher.launchCoordinates(
                         savedScooter.lastLocation!.latitude,
                         savedScooter.lastLocation!.longitude,
                       );
-                    },
+                    } : null,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          FlutterI18n.translate(context, "stats_last_ping", 
+                            translationParams: {
+                              "time": savedScooter.lastPing.calculateTimeDifferenceInShort(context).toLowerCase()
+                            }),
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        if (savedScooter.lastLocation != null) ...[
+                          Text(
+                            " near ",
+                            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                            ),
+                          ),
+                          Flexible(
+                            child: FutureBuilder<String?>(
+                              future: GeoHelper.getAddress(savedScooter.lastLocation!, context),
+                              builder: (context, snapshot) {
+                                if (snapshot.hasData) {
+                                  return Text(
+                                    snapshot.data!,
+                                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                      color: Theme.of(context).colorScheme.primary,
+                                      decoration: TextDecoration.underline,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
+                                  );
+                                } else {
+                                  return Text(
+                                    "${savedScooter.lastLocation!.latitude.toStringAsFixed(4)}, ${savedScooter.lastLocation!.longitude.toStringAsFixed(4)}",
+                                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                      color: Theme.of(context).colorScheme.primary,
+                                      decoration: TextDecoration.underline,
+                                    ),
+                                  );
+                                }
+                              },
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
                   ),
+                const SizedBox(height: 24),
                 Divider(
                   indent: 16,
                   endIndent: 16,
@@ -347,6 +319,7 @@ class SavedScooterCard extends StatelessWidget {
                 ),
                 if (!single) // only show this if there's more than one scooter
                   ListTile(
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16),
                     title: Text(FlutterI18n.translate(
                         context, "stats_scooter_auto_connect")),
                     subtitle: Text(savedScooter.autoConnect
@@ -372,8 +345,12 @@ class SavedScooterCard extends StatelessWidget {
                       .withValues(alpha: 0.1),
                 ),
                 ListTile(
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
                   title: const Text("ID"),
-                  subtitle: Text(savedScooter.id),
+                  subtitle: Text(
+                    savedScooter.id,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
                 Divider(
                   indent: 16,

--- a/lib/stats/scooter_section.dart
+++ b/lib/stats/scooter_section.dart
@@ -415,8 +415,10 @@ class SavedScooterCard extends StatelessWidget {
                                 context
                                     .read<ScooterService>()
                                     .startAutoRestart();
+                                rebuild();
+                                // Navigate back to main screen after successful connection
+                                Navigator.of(context).popUntil((route) => route.isFirst);
                               }
-                              rebuild();
                             } catch (e, stack) {
                               log.severe(
                                   "Couldn't connect to ${savedScooter.id}",

--- a/lib/stats/scooter_section.dart
+++ b/lib/stats/scooter_section.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../stats/stats_screen.dart';
 import '../onboarding_screen.dart';
+import '../scooter_screen.dart';
 import '../domain/saved_scooter.dart';
 import '../domain/scooter_state.dart';
 import '../geo_helper.dart';
@@ -408,16 +409,22 @@ class SavedScooterCard extends StatelessWidget {
                             try {
                               log.info(
                                   "Trying to connect to ${savedScooter.id}");
-                              await context
+                              
+                              // Start the connection but don't wait for it to fully complete
+                              // Just initiate it and navigate back immediately
+                              context
                                   .read<ScooterService>()
                                   .connectToScooterId(savedScooter.id);
+                              
                               if (context.mounted) {
                                 context
                                     .read<ScooterService>()
                                     .startAutoRestart();
                                 rebuild();
-                                // Navigate back to main screen after successful connection
-                                Navigator.of(context).popUntil((route) => route.isFirst);
+                                // Navigate back to main screen after initiating connection
+                                WidgetsBinding.instance.addPostFrameCallback((_) {
+                                  ScooterScreen.closeScreen();
+                                });
                               }
                             } catch (e, stack) {
                               log.severe(

--- a/lib/support_screen.dart
+++ b/lib/support_screen.dart
@@ -24,9 +24,7 @@ class SupportScreen extends StatelessWidget {
             ],
           ),
         ),
-        child: const SafeArea(
-          child: SupportSection(),
-        ),
+        child: const SupportSection(),
       ),
     );
   }


### PR DESCRIPTION
- Add Settings and Support icons to top-right corner of main screen
- Create individual screen wrappers (BatteryScreen, ScooterScreen, SettingsScreen, SupportScreen)
- Make battery area (bars + percentages + info icon) clickable to open battery screen
- Update scooter name navigation to go directly to scooter screen
- Position header icons like app bar without consuming vertical space
- Add padding to push main content below header icons

This replaces the overloaded multi-tab interface with direct access to all functionality
while maintaining consistent styling and navigation patterns across all screens.Feature summary

## QA checklist

- [ ] Read state (state & power state)
- [ ] Read primary battery SOC
- [ ] Read primary battery cycles
- [ ] Read secondary battery SOC
- [ ] Read secondary battery cycles
- [ ] Read seat closed
- [ ] Read handlebar
- [ ] Read AUX SOC
- [ ] Read CBB SOC
- [ ] Read CBB charging state
- [ ] Update ping
- [ ] SOCs are cached (after app restart)
- [ ] Commands can be sent (locking & hibernation)
