### PR TITLE
Fix: Prevent stuck 'Booting...' state when power manager unavailable

### DIFF
--- a/lib/domain/scooter_state.dart
+++ b/lib/domain/scooter_state.dart
@@ -47,6 +47,13 @@ enum ScooterState {
   }
 
   static ScooterState? fromStateAndPowerState(ScooterState? state, ScooterPowerState? powerState) {
+    // If vehicle state indicates scooter is clearly operational, trust it over a stale "booting" powerState
+    // This handles cases where power-manager.state is unset/stale but vehicle.state is accurate
+    if (powerState == ScooterPowerState.booting &&
+        (state == ScooterState.standby || state == ScooterState.ready || state == ScooterState.parked)) {
+      return state;
+    }
+
     switch (powerState) {
       case ScooterPowerState.booting:
         return ScooterState.booting;


### PR DESCRIPTION
## Summary
- Fixes stuck "Booting..." display when unu-pm service is not running or power-manager.state is unset in Redis
- App now trusts vehicle.state over stale power-manager booting status when scooter is clearly operational

## Problem
When the unu-pm service isn't running or fails to set power-manager.state in Redis, the BLE powerStateCharacteristic returns a stale "booting" value. The app previously prioritized this over the accurate vehicle.state, causing the UI to display "Booting..." indefinitely even when the scooter is in standby/ready/parked state.

## Solution
Added logic to `fromStateAndPowerState()` that trusts vehicle state (standby, ready, parked) over a "booting" powerState. This handles cases where power-manager.state is unset/stale while vehicle.state continues to update accurately.

## Test plan
- [x] Test with unu-pm service stopped - verify app shows correct state from vehicle.state
- [x] Test normal boot sequence - verify "Booting..." still shows during legitimate boot
- [x] Test hibernation/shutdown states - verify power state overrides still work correctly