### PR TITLE
fix: handle null command characteristic with user-friendly error

### DIFF
--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -917,11 +917,12 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       characteristicToSend = characteristic;
     }
 
-    // commandCharcteristic should never be null, so we can assume it's not
-    // if the given characteristic is null, we'll "fail" quitely by sending garbage to the default command characteristic instead
+    if (characteristicToSend == null) {
+      throw "Could not send command, move closer or reconnect";
+    }
 
     try {
-      characteristicToSend!.write(ascii.encode(command));
+      characteristicToSend.write(ascii.encode(command));
     } catch (e) {
       rethrow;
     }


### PR DESCRIPTION
## Summary
- Fixes ugly LateInitializationError toast when commandCharacteristic is unavailable due to poor reception
- Adds explicit null check in _sendCommand() before accessing command characteristic
- Provides user-friendly error message: "Could not send command, move closer or reconnect"
- Enables graceful degradation: users can still view scooter status even if commands are unavailable

## Problem
When connecting with poor Bluetooth reception, characteristic discovery can be incomplete. The commandCharacteristic may not be initialized, but the connection proceeds anyway since anyAreNull() doesn't check command characteristics. Later, when users try to lock/unlock the scooter, accessing the uninitialized field shows an ugly technical error toast: "LateInitializationError: Field 'commandCharacteristic' has not been initialized".

## Solution
Instead of showing a technical error, we now check if the characteristic is null and throw a clear, user-friendly error message: "Could not send command, move closer or reconnect".

## Test plan
- [ ] Connect to scooter with poor reception
- [ ] Verify user-friendly error message is shown in toast when trying to send commands
- [ ] Verify normal operation works with good connection