### PR TITLE
feat: migrate to self-hosted garage data

### DIFF
--- a/lib/stats/support_screen.dart
+++ b/lib/stats/support_screen.dart
@@ -238,12 +238,9 @@ class GarageWidget extends StatelessWidget {
   const GarageWidget({super.key});
 
   Future<List<Garage>> getGarages() async {
-    final response = await http.get(Uri.parse('https://unumotors.com/page-data/sq/d/2596243890.json'));
+    final response = await http.get(Uri.parse('https://reunu.github.io/unustasis-data/garages.json'));
     if (response.statusCode == 200) {
-      Map<String, dynamic> json = jsonDecode(utf8.decode(response.bodyBytes));
-      Map<String, dynamic> data = json['data'];
-      Map<String, dynamic> content = data['contentfulGaragesJson'];
-      List<dynamic> garages = content['garages'];
+      List<dynamic> garages = jsonDecode(utf8.decode(response.bodyBytes));
       return garages.map((garage) => Garage.fromJson(garage)).toList();
     } else {
       Logger("GarageWidget").severe('Failed to load garages', response.toString());


### PR DESCRIPTION
## Summary

Migrates garage data from unumotors.com to self-hosted source at [reunu/unustasis-data](https://github.com/reunu/unustasis-data). Enables correcting outdated information (starting with Wilhelm's details) while tracking upstream changes automatically.

## Changes

**App:**
- Fetch garages from `https://reunu.github.io/unustasis-data/garages.json` instead of unumotors.com
- Simplify JSON parsing (direct array instead of nested `data.contentfulGaragesJson.garages` structure)

**New repository: reunu/unustasis-data**
- `garages_upstream.json` - Original data from unumotors (~140 garages)
- `garages_overrides.json` - Our modifications (currently: Wilhelm garage updates)
- `garages.json` - Merged file published via GitHub Pages
- CI workflow runs weekly to fetch upstream, apply overrides, commit if changed

## Why

The upstream garage data from unumotors.com contains outdated information. For example:
- **Wilhelm garage** had wrong name ("Fahrzeugtechnik" → "Zweiradtechnik"), old address, and incorrect GPS coordinates

Self-hosting allows us to:
1. Apply corrections immediately without waiting for upstream
2. Track what we've changed vs. what came from upstream
3. Automatically detect when upstream data changes and reapply our modifications
4. Accept community corrections via GitHub issues

## Override System

Supports three operations with flexible multi-field matching:

**Update:**
```json
{
  "operation": "update",
  "match": { "name": "Fa. Wilhelm Fahrzeugtechnik" },
  "garage": { /* corrected data */ }
}
```

**Remove:**
```json
{
  "operation": "remove",
  "match": { "name": "Closed Garage" }
}
```

**Add:**
```json
{
  "operation": "add",
  "garage": { /* new garage record */ }
}
```

Multi-field matching supported for non-unique names: `"match": { "name": "Shop", "ShippingCity": "Berlin" }`