### PR TITLE
refactor: load background translations from i18n JSON files

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -270,5 +270,13 @@
     "event_type_lock": "{scooterName} verriegelt",
     "event_type_unlock": "{scooterName} entsperrt",
     "stats_auto_connect_how_to_toggle": "Gedrückt halten zum Ändern.",
-    "stats_nfc_not_enabled": "Bitte aktiviere NFC in den Handyeinstellungen."
+    "stats_nfc_not_enabled": "Bitte aktiviere NFC in den Handyeinstellungen.",
+    "time_just_now": "Vor kurzem",
+    "time_yesterday": "Gestern",
+    "time_day_before_yesterday": "Vorgestern",
+    "time_ago": "Vor {time}",
+    "lock_state_locked": "Verriegelt",
+    "lock_state_unlocked": "Offen",
+    "lock_state_unknown": "Unbekannt",
+    "error_generic": "FEHLER"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -270,5 +270,13 @@
     "event_type_wakeup": "Woke up {scooterName}",
     "event_type_hibernate": "Hibernated {scooterName}",
     "stats_auto_connect_how_to_toggle": "Long-press to change.",
-    "stats_nfc_not_enabled": "Please turn on NFC in your phone's settings"
+    "stats_nfc_not_enabled": "Please turn on NFC in your phone's settings",
+    "time_just_now": "Just now",
+    "time_yesterday": "Yesterday",
+    "time_day_before_yesterday": "Day before yesterday",
+    "time_ago": "{time} ago",
+    "lock_state_locked": "Locked",
+    "lock_state_unlocked": "Unlocked",
+    "lock_state_unknown": "Unknown",
+    "error_generic": "ERROR"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -269,5 +269,13 @@
     "event_type_wakeup": "{scooterName} réveillé",
     "event_type_hibernate": "{scooterName} mis en hibernation",
     "stats_auto_connect_how_to_toggle": "Appuyez longuement pour modifier.",
-    "stats_nfc_not_enabled": "Veuillez activer le NFC dans les paramètres de votre téléphone"
+    "stats_nfc_not_enabled": "Veuillez activer le NFC dans les paramètres de votre téléphone",
+    "time_just_now": "À l'instant",
+    "time_yesterday": "Hier",
+    "time_day_before_yesterday": "Avant-hier",
+    "time_ago": "Il y a {time}",
+    "lock_state_locked": "Verrouillé",
+    "lock_state_unlocked": "Déverrouillé",
+    "lock_state_unknown": "Inconnu",
+    "error_generic": "ERREUR"
 }

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -269,5 +269,13 @@
     "event_type_wakeup": "{scooterName} gewekt",
     "event_type_hibernate": "{scooterName} in slaapstand gezet",
     "stats_auto_connect_how_to_toggle": "Lang indrukken om te wijzigen.",
-    "stats_nfc_not_enabled": "Schakel NFC in via de instellingen van je telefoon"
+    "stats_nfc_not_enabled": "Schakel NFC in via de instellingen van je telefoon",
+    "time_just_now": "Zojuist",
+    "time_yesterday": "Gisteren",
+    "time_day_before_yesterday": "Eergisteren",
+    "time_ago": "{time} geleden",
+    "lock_state_locked": "Vergrendeld",
+    "lock_state_unlocked": "Ontgrendeld",
+    "lock_state_unknown": "Onbekend",
+    "error_generic": "FOUT"
 }

--- a/assets/i18n/pi.json
+++ b/assets/i18n/pi.json
@@ -248,5 +248,13 @@
     "event_type_unlock": "Set sail on {scooterName}",
     "event_type_wakeup": "Awoke {scooterName} from slumber",
     "stats_auto_connect_how_to_toggle": "Hold steady to change.",
-    "stats_nfc_not_enabled": "You gotta turn on your phone's NFC first, matey!"
+    "stats_nfc_not_enabled": "You gotta turn on your phone's NFC first, matey!",
+    "time_just_now": "Just now",
+    "time_yesterday": "Yesterday",
+    "time_day_before_yesterday": "Two sunsets ago",
+    "time_ago": "{time} ago",
+    "lock_state_locked": "Battened down",
+    "lock_state_unlocked": "Open seas",
+    "lock_state_unknown": "Lost at sea",
+    "error_generic": "BLIMEY!"
 }

--- a/lib/background/background_i18n.dart
+++ b/lib/background/background_i18n.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class BackgroundI18n {
+  static final BackgroundI18n _instance = BackgroundI18n._();
+  static BackgroundI18n get instance => _instance;
+  BackgroundI18n._();
+
+  Map<String, dynamic> _translations = {};
+  Map<String, dynamic> _fallback = {};
+  bool _initialized = false;
+
+  Future<void> init() async {
+    if (_initialized) return;
+    String lang = (await SharedPreferencesAsync().getString('savedLocale')) ??
+        PlatformDispatcher.instance.locale.languageCode;
+    _fallback = await _load('en');
+    _translations = (lang == 'en') ? _fallback : await _load(lang);
+    _initialized = true;
+  }
+
+  Future<Map<String, dynamic>> _load(String lang) async {
+    try {
+      return jsonDecode(await rootBundle.loadString('assets/i18n/$lang.json'));
+    } catch (_) {
+      return {};
+    }
+  }
+
+  String translate(String key) => (_translations[key] ?? _fallback[key] ?? key) as String;
+}

--- a/lib/background/bg_service.dart
+++ b/lib/background/bg_service.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import 'package:pausable_timer/pausable_timer.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../background/background_i18n.dart';
 import '../background/widget_handler.dart';
 import '../domain/statistics_helper.dart';
 import '../flutter/blue_plus_mockable.dart';
@@ -67,6 +68,7 @@ Future<bool> onIosBackground(ServiceInstance service) async {
   // Ensure that the Flutter engine is initialized.
   WidgetsFlutterBinding.ensureInitialized();
   DartPluginRegistrant.ensureInitialized();
+  await BackgroundI18n.instance.init();
   // Set up a scooter service instance.
   scooterService = ScooterService(fbp, isInBackgroundService: true);
   // Make sure scooterService has time to initialize all values
@@ -116,7 +118,9 @@ void onStart(ServiceInstance service) async {
     print("[${record.level.name}] ${record.time}: ${record.message} ${record.error ?? ""} ${record.stackTrace ?? ""}");
   });
   Logger("bgservice").info("Background service started!");
+  WidgetsFlutterBinding.ensureInitialized();
   DartPluginRegistrant.ensureInitialized();
+  await BackgroundI18n.instance.init();
 
   backgroundScanEnabled = (await SharedPreferences.getInstance()).getBool("backgroundScan") ?? false;
 

--- a/lib/background/translate_static.dart
+++ b/lib/background/translate_static.dart
@@ -1,290 +1,69 @@
-import 'dart:ui';
-
+import '../background/background_i18n.dart';
 import '../background/widget_handler.dart';
 import '../domain/scooter_state.dart';
 
-extension ScooterStateName on ScooterState? {
-  String getNameStatic({String? languageCode}) {
-    String lang = languageCode ?? PlatformDispatcher.instance.locale.languageCode;
+const _stateKeys = {
+  ScooterState.off: 'state_name_off',
+  ScooterState.standby: 'state_name_standby',
+  ScooterState.parked: 'state_name_parked',
+  ScooterState.ready: 'state_name_ready',
+  ScooterState.updating: 'state_name_updating',
+  ScooterState.waitingSeatbox: 'state_name_waiting_seatbox',
+  ScooterState.waitingHibernation: 'state_name_waiting_hibernation',
+  ScooterState.waitingHibernationAdvanced: 'state_name_waiting_hibernation',
+  ScooterState.waitingHibernationSeatbox: 'state_name_waiting_hibernation',
+  ScooterState.waitingHibernationConfirm: 'state_name_waiting_hibernation',
+  ScooterState.hibernating: 'state_name_hibernating',
+  ScooterState.hibernatingImminent: 'state_name_hibernating_imminent',
+  ScooterState.booting: 'state_name_booting',
+  ScooterState.linking: 'state_name_linking',
+  ScooterState.disconnected: 'state_name_disconnected',
+  ScooterState.shuttingDown: 'state_name_shutting_down',
+  ScooterState.unknown: 'state_name_unknown',
+};
 
-    if (lang == "de") {
-      switch (this) {
-        case ScooterState.off:
-          return "Aus";
-        case ScooterState.standby:
-          return "Standby";
-        case ScooterState.parked:
-          return "Geparkt";
-        case ScooterState.ready:
-          return "Bereit";
-        case ScooterState.updating:
-          return "Wird aktualisiert";
-        case ScooterState.waitingSeatbox:
-          return "Warte auf Sitzbox";
-        case ScooterState.waitingHibernation:
-        case ScooterState.waitingHibernationAdvanced:
-        case ScooterState.waitingHibernationSeatbox:
-        case ScooterState.waitingHibernationConfirm:
-          return "Manueller Ruhezustand startet";
-        case ScooterState.hibernating:
-          return "Tiefschlaf";
-        case ScooterState.hibernatingImminent:
-          return "Schläft bald...";
-        case ScooterState.booting:
-          return "Fährt hoch...";
-        case ScooterState.linking:
-          return "Suche...";
-        case ScooterState.disconnected:
-          return "Getrennt";
-        case ScooterState.shuttingDown:
-          return "Herunterfahren...";
-        case ScooterState.unknown:
-        default:
-          return "Unbekannt";
-      }
-    } else if (lang == "fr") {
-      switch (this) {
-        case ScooterState.off:
-          return "Éteint";
-        case ScooterState.standby:
-          return "Veille";
-        case ScooterState.parked:
-          return "Stationné";
-        case ScooterState.ready:
-          return "Prêt";
-        case ScooterState.updating:
-          return "Mise à jour";
-        case ScooterState.waitingSeatbox:
-          return "En attente du coffre";
-        case ScooterState.waitingHibernation:
-        case ScooterState.waitingHibernationAdvanced:
-        case ScooterState.waitingHibernationSeatbox:
-        case ScooterState.waitingHibernationConfirm:
-          return "Hibernation manuelle en cours";
-        case ScooterState.hibernating:
-          return "En hibernation";
-        case ScooterState.hibernatingImminent:
-          return "Hibernation imminente...";
-        case ScooterState.booting:
-          return "Démarrage...";
-        case ScooterState.linking:
-          return "Recherche...";
-        case ScooterState.disconnected:
-          return "Déconnecté";
-        case ScooterState.shuttingDown:
-          return "Arrêt en cours...";
-        case ScooterState.unknown:
-        default:
-          return "Inconnu";
-      }
-    } else if (lang == "nl") {
-      switch (this) {
-        case ScooterState.off:
-          return "Uit";
-        case ScooterState.standby:
-          return "Stand-by";
-        case ScooterState.parked:
-          return "Geparkeerd";
-        case ScooterState.ready:
-          return "Klaar";
-        case ScooterState.updating:
-          return "Bijwerken";
-        case ScooterState.waitingSeatbox:
-          return "Wachten op buddy";
-        case ScooterState.waitingHibernation:
-        case ScooterState.waitingHibernationAdvanced:
-        case ScooterState.waitingHibernationSeatbox:
-        case ScooterState.waitingHibernationConfirm:
-          return "Handmatige slaapstand starten";
-        case ScooterState.hibernating:
-          return "In slaapstand";
-        case ScooterState.hibernatingImminent:
-          return "Gaat in slaapstand...";
-        case ScooterState.booting:
-          return "Opstarten...";
-        case ScooterState.linking:
-          return "Zoeken...";
-        case ScooterState.disconnected:
-          return "Niet verbonden";
-        case ScooterState.shuttingDown:
-          return "Afsluiten...";
-        case ScooterState.unknown:
-        default:
-          return "Onbekend";
-      }
-    } else {
-      switch (this) {
-        case ScooterState.off:
-          return "Off";
-        case ScooterState.standby:
-          return "Stand-by";
-        case ScooterState.parked:
-          return "Parked";
-        case ScooterState.ready:
-          return "Ready";
-        case ScooterState.updating:
-          return "Updating";
-        case ScooterState.waitingSeatbox:
-          return "Waiting on Seatbox";
-        case ScooterState.waitingHibernation:
-        case ScooterState.waitingHibernationAdvanced:
-        case ScooterState.waitingHibernationSeatbox:
-        case ScooterState.waitingHibernationConfirm:
-          return "Manual hibernation starting";
-        case ScooterState.hibernating:
-          return "Hibernating";
-        case ScooterState.hibernatingImminent:
-          return "Hibernating soon...";
-        case ScooterState.booting:
-          return "Booting...";
-        case ScooterState.linking:
-          return "Searching...";
-        case ScooterState.disconnected:
-          return "Disconnected";
-        case ScooterState.shuttingDown:
-          return "Shutting down...";
-        case ScooterState.unknown:
-        default:
-          return "Unknown";
-      }
-    }
+const _actionKeys = {
+  'lock': 'controls_lock',
+  'unlock': 'controls_unlock',
+  'openseat': 'home_seat_button_closed',
+};
+
+final _i18n = BackgroundI18n.instance;
+
+extension ScooterStateName on ScooterState? {
+  String getNameStatic() {
+    final key = _stateKeys[this] ?? 'state_name_unknown';
+    return _i18n.translate(key);
   }
 }
 
 String getLocalizedNotificationAction(String actionId) {
-  String lang = PlatformDispatcher.instance.locale.languageCode;
-
-  if (lang == "de") {
-    switch (actionId) {
-      case "lock":
-        return "Schließen";
-      case "unlock":
-        return "Öffnen";
-      case "openseat":
-        return "Sitz öffnen";
-      default:
-        return "FEHLER";
-    }
-  } else if (lang == "fr") {
-    switch (actionId) {
-      case "lock":
-        return "Verrouiller";
-      case "unlock":
-        return "Déverrouiller";
-      case "openseat":
-        return "Ouvrir le coffre";
-      default:
-        return "ERREUR";
-    }
-  } else if (lang == "nl") {
-    switch (actionId) {
-      case "lock":
-        return "Vergrendelen";
-      case "unlock":
-        return "Ontgrendelen";
-      case "openseat":
-        return "Buddy openen";
-      default:
-        return "FOUT";
-    }
-  } else {
-    switch (actionId) {
-      case "lock":
-        return "Lock";
-      case "unlock":
-        return "Unlock";
-      case "openseat":
-        return "Open seat";
-      default:
-        return "ERROR";
-    }
-  }
+  final key = _actionKeys[actionId];
+  return key != null ? _i18n.translate(key) : _i18n.translate('error_generic');
 }
 
 String? getLocalizedTimeDiff(DateTime? lastPing) {
-  String lang = PlatformDispatcher.instance.locale.languageCode;
-
-  if (lastPing == null) {
-    return null;
-  }
+  if (lastPing == null) return null;
 
   String? timeDiff = lastPing.calculateTimeDifferenceInShort();
 
-  if (lang == "de") {
-    if (timeDiff == null) {
-      return "Vor kurzem";
-    } else if (timeDiff == "1d") {
-      return "Gestern";
-    } else if (timeDiff == "2d") {
-      return "Vorgestern";
-    }
-    return "Vor $timeDiff";
-  } else if (lang == "fr") {
-    if (timeDiff == null) {
-      return "À l'instant";
-    } else if (timeDiff == "1d") {
-      return "Hier";
-    } else if (timeDiff == "2d") {
-      return "Avant-hier";
-    }
-    return "Il y a $timeDiff";
-  } else if (lang == "nl") {
-    if (timeDiff == null) {
-      return "Zojuist";
-    } else if (timeDiff == "1d") {
-      return "Gisteren";
-    } else if (timeDiff == "2d") {
-      return "Eergisteren";
-    }
-    return "$timeDiff geleden";
-  } else {
-    if (timeDiff == null) {
-      return "Just now";
-    } else if (timeDiff == "1d") {
-      return "Yesterday";
-    }
-    return "$timeDiff ago";
+  if (timeDiff == null) {
+    return _i18n.translate('time_just_now');
+  } else if (timeDiff == '1d') {
+    return _i18n.translate('time_yesterday');
+  } else if (timeDiff == '2d') {
+    return _i18n.translate('time_day_before_yesterday');
   }
+  return _i18n.translate('time_ago').replaceAll('{time}', timeDiff);
 }
 
 String getLocalizedLockStateName(bool? locked) {
-  String lang = PlatformDispatcher.instance.locale.languageCode;
-
-  if (lang == "de") {
-    switch (locked) {
-      case true:
-        return "Verriegelt";
-      case false:
-        return "Offen";
-      default:
-        return "Unbekannt";
-    }
-  } else if (lang == "fr") {
-    switch (locked) {
-      case true:
-        return "Verrouillé";
-      case false:
-        return "Déverrouillé";
-      default:
-        return "Inconnu";
-    }
-  } else if (lang == "nl") {
-    switch (locked) {
-      case true:
-        return "Vergrendeld";
-      case false:
-        return "Ontgrendeld";
-      default:
-        return "Onbekend";
-    }
-  } else {
-    switch (locked) {
-      case true:
-        return "Locked";
-      case false:
-        return "Unlocked";
-      default:
-        return "Unknown";
-    }
+  switch (locked) {
+    case true:
+      return _i18n.translate('lock_state_locked');
+    case false:
+      return _i18n.translate('lock_state_unlocked');
+    default:
+      return _i18n.translate('lock_state_unknown');
   }
 }

--- a/lib/background/widget_handler.dart
+++ b/lib/background/widget_handler.dart
@@ -11,6 +11,7 @@ import 'package:latlong2/latlong.dart';
 
 import 'package:workmanager/workmanager.dart';
 
+import '../background/background_i18n.dart';
 import '../background/translate_static.dart';
 import '../background/bg_service.dart';
 import '../domain/scooter_state.dart';
@@ -214,6 +215,8 @@ Future<void> setWidgetScanning(bool scanning) async {
 
 @pragma("vm:entry-point")
 FutureOr<void> backgroundCallback(Uri? data) async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await BackgroundI18n.instance.init();
   await HomeWidget.setAppGroupId('group.de.freal.unustasis');
 
   try {
@@ -252,6 +255,7 @@ void workmanagerCallback() {
     print("Workmanager task executing: $task");
     WidgetsFlutterBinding.ensureInitialized();
     DartPluginRegistrant.ensureInitialized();
+    await BackgroundI18n.instance.init();
     if (task == widgetTaskID) {
       await updateWidgetPing();
     } else {


### PR DESCRIPTION
## Summary

- Replace hardcoded per-language switch blocks in `translate_static.dart` with key lookups against the same JSON files used by FlutterI18n
- New `BackgroundI18n` singleton loads and caches translations via `rootBundle` — adding a language no longer requires touching Dart code
- Respect user's in-app language choice (`savedLocale`) instead of always using system locale
- Add `WidgetsFlutterBinding.ensureInitialized()` to `onStart()` and `backgroundCallback()` entry points (was missing)

## Changes

| File | What |
|------|------|
| `lib/background/background_i18n.dart` | **New** — JSON loader + cache singleton |
| `lib/background/translate_static.dart` | ~250 → ~70 lines, zero per-language code |
| `lib/background/bg_service.dart` | Init binding + BackgroundI18n in entry points |
| `lib/background/widget_handler.dart` | Same |
| `assets/i18n/{en,de,fr,pi}.json` | 8 new keys each (`time_*`, `lock_state_*`, `error_generic`) |

## Test plan

- [x] `flutter analyze` — no issues
- [ ] Verify widget shows correct state names in each language
- [ ] Verify notification actions show correct labels
- [ ] Verify "last seen" time strings render correctly
- [ ] Verify lock state name on widget matches language
- [ ] Test with savedLocale set to non-system language (e.g. system=en, app=de)