### PR TITLE
fix: update NFC availability check for nfc_manager 4.x

### DIFF
--- a/lib/stats/battery_screen.dart
+++ b/lib/stats/battery_screen.dart
@@ -214,8 +214,15 @@ class _BatteryScreenState extends State<BatteryScreen> {
                               ),
                               onPressed: () async {
                                 // Check availability
-                                NfcAvailability availability = await NfcManager.instance.checkAvailability();
-                                if (availability == NfcAvailability.unsupported && context.mounted) {
+                                bool nfcEnabled;
+                                bool nfcSupported = true;
+                                try {
+                                  nfcEnabled = await NfcManager.instance.isAvailable();
+                                } catch (_) {
+                                  nfcEnabled = false;
+                                  nfcSupported = false;
+                                }
+                                if (!nfcSupported && context.mounted) {
                                   Fluttertoast.showToast(
                                     msg: FlutterI18n.translate(context, "stats_nfc_not_available"),
                                   );
@@ -223,7 +230,7 @@ class _BatteryScreenState extends State<BatteryScreen> {
                                     nfcScanning = false;
                                   });
                                   return;
-                                } else if (availability == NfcAvailability.disabled && context.mounted) {
+                                } else if (!nfcEnabled && context.mounted) {
                                   Fluttertoast.showToast(
                                     msg: FlutterI18n.translate(context, "stats_nfc_not_enabled"),
                                   );


### PR DESCRIPTION
`checkAvailability()` and `NfcAvailability` were removed in nfc_manager 4.x. The new API only exposes `isAvailable() → bool`, which calls `NfcAdapter.isEnabled()` on Android.

To preserve the distinction between unsupported hardware and NFC being disabled:
- No NFC hardware → `getAdapter()` in the native plugin throws `FlutterError("not_supported", ...)`, caught as an exception → shows "NFC is not supported on your phone"
- NFC hardware present but disabled → `isAvailable()` returns `false` cleanly → shows "Please turn on NFC in your phone's settings"

Fixes build failure introduced by nfc_manager being resolved to 4.0.2.