### PR TITLE
fix: parse CBB voltage and capacity as full uint32

### DIFF
--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -224,8 +224,8 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
     battery.primarySOC = 53;
     battery.secondarySOC = 100;
     battery.cbbSOC = 98;
-    battery.cbbVoltage = 15000;
-    battery.cbbCapacity = 33000;
+    battery.cbbVoltage = 3700;
+    battery.cbbCapacity = 3000;
     battery.cbbCharging = false;
     battery.auxSOC = 100;
     battery.auxVoltage = 15000;

--- a/lib/state/battery_state.dart
+++ b/lib/state/battery_state.dart
@@ -61,13 +61,15 @@ class BatteryState {
       onUpdate();
     });
     subscribeToIntValue(chars.cbbVoltageCharacteristic!, 'CBB Voltage', (voltage) {
-      cbbVoltage = voltage;
+      // Cell voltage is a uint32 in µV; store as mV for display.
+      cbbVoltage = voltage ~/ 1000;
       onUpdate();
-    }, singleByte: true);
+    });
     subscribeToIntValue(chars.cbbCapacityCharacteristic!, 'CBB Capacity', (capacity) {
-      cbbCapacity = capacity;
+      // Remaining capacity is a uint32 in µAh; store as mAh for display.
+      cbbCapacity = capacity ~/ 1000;
       onUpdate();
-    }, singleByte: true);
+    });
 
     // AUX battery
     subscribeToIntValue(chars.auxSOCCharacteristic!, 'AUX SOC', (soc) {


### PR DESCRIPTION
## Problem

The CBB diagnostics screen shows randomly fluctuating voltage and capacity, while the same values are stable and correct everywhere else (e.g. read off the scooter over USOCK into Redis).

## Cause

`CB_BATTERY_CELL_VOLTAGE` (`...0065`) and `CB_BATTERY_REMAINING_CAPACITY` (`...0063`) are 4-byte `uint32` GATT characteristics, but `BatteryState` subscribed to them with `singleByte: true`, so only `data[0]` (the least-significant byte) was kept.

The low byte of a multi-thousand value churns through 0-255 with every tiny real change, so the displayed number wanders chaotically while the true value barely moves. SOC genuinely is a `uint8`, so `singleByte` there is correct and untouched.

## Fix

- Drop `singleByte: true` for CBB voltage and capacity so they parse as `uint32` via the existing `_bytesToUint32` path.
- The firmware reports cell voltage in µV and remaining capacity in µAh (per the MAX1730x fuel gauge: 78.125 µV/LSB). Convert µV -> mV and µAh -> mAh so the values match the existing `mV` / `mAh` labels on the diagnostics dialog. This keeps the stored fields in the same units as AUX voltage, so the display code stays uniform.
- Update the demo seed values to the corrected units.

## Testing

`flutter analyze lib/state/battery_state.dart lib/scooter_service.dart` -> No issues found.