### PR TITLE
Change auto-hibernate minimum duration from immediate to 1 hour

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -327,7 +327,7 @@
     "ls_settings_auto_hibernate_error": "Auto-Tiefschlaf-Zeit konnte nicht aktualisiert werden: {error}",
     "ls_settings_duration_hint": "Dauer",
     "ls_settings_duration_never": "Nie",
-    "ls_settings_duration_1_min": "1 Minute",
+    "ls_settings_duration_3_min": "3 Minuten",
     "ls_settings_duration_5_min": "5 Minuten",
     "ls_settings_duration_10_min": "10 Minuten",
     "ls_settings_duration_1_hour": "1 Stunde",

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -330,7 +330,7 @@
     "ls_settings_duration_1_min": "1 Minute",
     "ls_settings_duration_5_min": "5 Minuten",
     "ls_settings_duration_10_min": "10 Minuten",
-    "ls_settings_duration_immediately": "Sofort",
+    "ls_settings_duration_1_hour": "1 Stunde",
     "ls_settings_duration_1_day": "1 Tag",
     "ls_settings_duration_3_days": "3 Tage",
     "ls_settings_duration_7_days": "7 Tage",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -330,7 +330,7 @@
     "ls_settings_duration_1_min": "1 minute",
     "ls_settings_duration_5_min": "5 minutes",
     "ls_settings_duration_10_min": "10 minutes",
-    "ls_settings_duration_immediately": "Immediately",
+    "ls_settings_duration_1_hour": "1 hour",
     "ls_settings_duration_1_day": "1 day",
     "ls_settings_duration_3_days": "3 days",
     "ls_settings_duration_7_days": "7 days",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -327,7 +327,7 @@
     "ls_settings_auto_hibernate_error": "Failed to update auto-hibernate time: {error}",
     "ls_settings_duration_hint": "Duration",
     "ls_settings_duration_never": "Never",
-    "ls_settings_duration_1_min": "1 minute",
+    "ls_settings_duration_3_min": "3 minutes",
     "ls_settings_duration_5_min": "5 minutes",
     "ls_settings_duration_10_min": "10 minutes",
     "ls_settings_duration_1_hour": "1 hour",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -329,7 +329,7 @@
     "ls_settings_duration_1_min": "1 minute",
     "ls_settings_duration_5_min": "5 minutes",
     "ls_settings_duration_10_min": "10 minutes",
-    "ls_settings_duration_immediately": "Immédiatement",
+    "ls_settings_duration_1_hour": "1 heure",
     "ls_settings_duration_1_day": "1 jour",
     "ls_settings_duration_3_days": "3 jours",
     "ls_settings_duration_7_days": "7 jours",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -326,7 +326,7 @@
     "ls_settings_auto_hibernate_error": "Impossible de mettre à jour l'hibernation auto : {error}",
     "ls_settings_duration_hint": "Durée",
     "ls_settings_duration_never": "Jamais",
-    "ls_settings_duration_1_min": "1 minute",
+    "ls_settings_duration_3_min": "3 minutes",
     "ls_settings_duration_5_min": "5 minutes",
     "ls_settings_duration_10_min": "10 minutes",
     "ls_settings_duration_1_hour": "1 heure",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -330,7 +330,7 @@
     "ls_settings_duration_1_min": "1 minuut",
     "ls_settings_duration_5_min": "5 minuten",
     "ls_settings_duration_10_min": "10 minuten",
-    "ls_settings_duration_immediately": "Onmiddellijk",
+    "ls_settings_duration_1_hour": "1 uur",
     "ls_settings_duration_1_day": "1 dag",
     "ls_settings_duration_3_days": "3 dagen",
     "ls_settings_duration_7_days": "7 dagen",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -327,7 +327,7 @@
     "ls_settings_auto_hibernate_error": "Auto-sluimertijd bijwerken mislukt: {error}",
     "ls_settings_duration_hint": "Duur",
     "ls_settings_duration_never": "Nooit",
-    "ls_settings_duration_1_min": "1 minuut",
+    "ls_settings_duration_3_min": "3 minuten",
     "ls_settings_duration_5_min": "5 minuten",
     "ls_settings_duration_10_min": "10 minuten",
     "ls_settings_duration_1_hour": "1 uur",

--- a/assets/i18n/pi.json
+++ b/assets/i18n/pi.json
@@ -308,7 +308,7 @@
     "ls_settings_duration_1_min": "1 minute",
     "ls_settings_duration_5_min": "5 minutes",
     "ls_settings_duration_10_min": "10 minutes",
-    "ls_settings_duration_immediately": "Immediately",
+    "ls_settings_duration_1_hour": "1 hour",
     "ls_settings_duration_1_day": "1 day",
     "ls_settings_duration_3_days": "3 days",
     "ls_settings_duration_7_days": "7 days",

--- a/assets/i18n/pi.json
+++ b/assets/i18n/pi.json
@@ -305,7 +305,7 @@
     "ls_settings_auto_hibernate_error": "Failed to update auto-slumber timing: {error}",
     "ls_settings_duration_hint": "Duration",
     "ls_settings_duration_never": "Never",
-    "ls_settings_duration_1_min": "1 minute",
+    "ls_settings_duration_3_min": "3 minutes",
     "ls_settings_duration_5_min": "5 minutes",
     "ls_settings_duration_10_min": "10 minutes",
     "ls_settings_duration_1_hour": "1 hour",

--- a/lib/ls_settings_screen.dart
+++ b/lib/ls_settings_screen.dart
@@ -104,8 +104,8 @@ class _LsSettingsScreenState extends State<LsSettingsScreen> {
                 child: Text(FlutterI18n.translate(context, "ls_settings_duration_never")),
               ),
               DropdownMenuItem(
-                value: 60,
-                child: Text(FlutterI18n.translate(context, "ls_settings_duration_1_min")),
+                value: 180,
+                child: Text(FlutterI18n.translate(context, "ls_settings_duration_3_min")),
               ),
               DropdownMenuItem(
                 value: 300,

--- a/lib/ls_settings_screen.dart
+++ b/lib/ls_settings_screen.dart
@@ -165,8 +165,8 @@ class _LsSettingsScreenState extends State<LsSettingsScreen> {
             value: _autoHibernateDuration,
             items: [
               DropdownMenuItem(
-                value: 1,
-                child: Text(FlutterI18n.translate(context, "ls_settings_duration_immediately")),
+                value: 3600,
+                child: Text(FlutterI18n.translate(context, "ls_settings_duration_1_hour")),
               ),
               DropdownMenuItem(
                 value: 86400,


### PR DESCRIPTION
## Feature summary

Updates the auto-hibernation settings to change the minimum duration option from "Immediately" (1 second) to "1 hour" (3600 seconds). This provides a more practical minimum threshold for the auto-hibernation feature.

### Changes
- Updated the first dropdown menu item in the auto-hibernation duration selector from value `1` to `3600` (1 hour in seconds)
- Replaced the i18n key `ls_settings_duration_immediately` with `ls_settings_duration_1_hour` across all supported languages (English, German, French, Dutch, and Pirate English)

## QA checklist

- [ ] Read state (state & power state)
- [ ] Read primary battery SOC
- [ ] Read primary battery cycles
- [ ] Read secondary battery SOC
- [ ] Read secondary battery cycles
- [ ] Read seat closed
- [ ] Read handlebar
- [ ] Read AUX SOC
- [ ] Read CBB SOC
- [ ] Read CBB charging state
- [ ] Update ping
- [ ] SOCs are cached (after app restart)
- [ ] Commands can be sent (locking & hibernation)
- [ ] Auto-hibernation duration dropdown displays "1 hour" as the first option
- [ ] Auto-hibernation with 1 hour duration works correctly

https://claude.ai/code/session_01DghMPUVUC6M1wpcW67U5jV