### PR TITLE
Add long-write support and truncation for extended BLE commands

### DIFF
--- a/lib/service/ble_commands.dart
+++ b/lib/service/ble_commands.dart
@@ -52,12 +52,20 @@ Future<List<T>> _readExtendedList<T>(
   return results;
 }
 
+// Maximum payload for the extended command characteristic. The basic command
+// characteristic is limited to 20 bytes (default BLE MTU minus ATT overhead),
+// but the extended characteristic uses allowLongWrite so it can carry more.
+// Keep this well under typical negotiated MTUs (185–512 bytes) and the
+// scooter's own command-buffer size.
+const int _extendedCommandMaxBytes = 100;
+
 /// Writes an ASCII command to the scooter's BLE command characteristic.
 Future<void> sendCommand(
   BluetoothDevice? scooter,
   CharacteristicRepository characteristicRepository,
   String command, {
   BluetoothCharacteristic? characteristic,
+  bool allowLongWrite = false,
 }) async {
   log.fine("Sending command: $command");
   if (scooter == null) {
@@ -73,7 +81,16 @@ Future<void> sendCommand(
     throw "Could not send command, move closer or reconnect";
   }
 
-  await target.write(ascii.encode(command));
+  await target.write(ascii.encode(command), allowLongWrite: allowLongWrite);
+}
+
+/// Returns [name] truncated so that [prefix] + "," + name fits within
+/// [_extendedCommandMaxBytes]. Returns null when there is no room at all.
+String? _truncateNavName(String prefix, String? name) {
+  if (name == null || name.isEmpty) return null;
+  final available = _extendedCommandMaxBytes - prefix.length - 1; // -1 for ","
+  if (available <= 0) return null;
+  return name.length > available ? name.substring(0, available) : name;
 }
 
 /// Sends a command to the extended characteristic (only available on librescoot
@@ -102,7 +119,7 @@ Future<String?> _sendLsExtendedCommandUnguarded(
 
   await resp.setNotifyValue(true);
   try {
-    await sendCommand(scooter, repo, command, characteristic: cmd);
+    await sendCommand(scooter, repo, command, characteristic: cmd, allowLongWrite: true);
     return await resp.onValueReceived
         .where((v) => v.isNotEmpty)
         .map((v) => ascii.decode(v).replaceAll('\x00', ''))
@@ -298,10 +315,13 @@ Future<void> navigateCommand(
   CharacteristicRepository repo,
   NavDestination destination,
 ) async {
+  final base = "nav:dest ${destination.location.latitude},${destination.location.longitude}";
+  final name = _truncateNavName(base, destination.name);
+  final command = name != null ? "$base,$name" : base;
   final response = await sendLsExtendedCommand(
     scooter,
     repo,
-    "nav:dest ${destination.location.latitude},${destination.location.longitude}${destination.name != null ? ",${destination.name}" : ""}",
+    command,
   );
   if (response != "nav:ok") {
     log.severe("Failed to navigate, response: $response");
@@ -336,10 +356,12 @@ Future<String> saveNavDestinationCommand(
     log.warning("Destination name cannot be empty when storing as favorite");
     throw "Destination name cannot be empty when storing as favorite";
   }
+  final base = "nav:fav:add ${destination.location.latitude},${destination.location.longitude}";
+  final name = _truncateNavName(base, destination.name) ?? destination.name!;
   final response = await sendLsExtendedCommand(
     scooter,
     repo,
-    "nav:fav:add ${destination.location.latitude},${destination.location.longitude},${destination.name}",
+    "$base,$name",
   );
 
   String? id = response?.split(":").last;


### PR DESCRIPTION
## Feature summary

This change adds support for long-write BLE operations on extended commands and implements command payload truncation to ensure navigation commands stay within the 100-byte extended command characteristic limit.

### Changes:
- Added `allowLongWrite` parameter to `sendCommand()` to support payloads larger than the basic 20-byte BLE MTU
- Defined `_extendedCommandMaxBytes` constant (100 bytes) with documentation explaining the limit
- Implemented `_truncateNavName()` helper to safely truncate destination names so complete navigation commands fit within payload limits
- Updated `navigateCommand()` to use truncation when building nav:dest commands
- Updated `saveNavDestinationCommand()` to use truncation when building nav:fav:add commands
- Updated `_sendLsExtendedCommandUnguarded()` to enable long-write for extended characteristic operations

### Rationale:
Navigation commands can exceed the basic BLE characteristic size when destination names are long. The extended characteristic supports long-write operations, but we must ensure the complete command (prefix + coordinates + name) stays within reasonable bounds to avoid exceeding the scooter's command buffer and typical negotiated MTU sizes.

## QA checklist

- [ ] Read state (state & power state)
- [ ] Read primary battery SOC
- [ ] Read primary battery cycles
- [ ] Read secondary battery SOC
- [ ] Read secondary battery cycles
- [ ] Read seat closed
- [ ] Read handlebar
- [ ] Read AUX SOC
- [ ] Read CBB SOC
- [ ] Read CBB charging state
- [ ] Update ping
- [ ] SOCs are cached (after app restart)
- [ ] Commands can be sent (locking & hibernation)
- [ ] Navigation commands work with long destination names
- [ ] Navigation favorites can be saved with long destination names

https://claude.ai/code/session_014jYmtyhZw9ZY6A6FYnyfy3