### PR TITLE
Fix misleading 'suspending' power-state label

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -64,7 +64,7 @@
     "state_name_linking": "Verbindet...",
     "power_state_booting": "Fährt hoch...",
     "power_state_running": "Läuft",
-    "power_state_suspending": "Geht in Ruhezustand...",
+    "power_state_suspending": "Im Ruhezustand",
     "power_state_suspending_imminent": "Ruhezustand bald",
     "power_state_hibernating": "Im Tiefschlaf",
     "power_state_hibernating_imminent": "Beginne Tiefschlaf...",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -65,7 +65,7 @@
     "state_name_scanning": "Scanning...",
     "power_state_booting": "Booting...",
     "power_state_running": "Running",
-    "power_state_suspending": "Suspending",
+    "power_state_suspending": "Asleep",
     "power_state_suspending_imminent": "Suspending soon...",
     "power_state_hibernating": "Hibernating",
     "power_state_hibernating_imminent": "Entering hibernation...",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -65,7 +65,7 @@
     "state_name_scanning": "Analyse...",
     "power_state_booting": "Démarrage...",
     "power_state_running": "En marche",
-    "power_state_suspending": "Mise en veille",
+    "power_state_suspending": "En veille",
     "power_state_suspending_imminent": "Mise en veille imminente...",
     "power_state_hibernating": "En hibernation",
     "power_state_hibernating_imminent": "Entrée en hibernation...",

--- a/assets/i18n/pi.json
+++ b/assets/i18n/pi.json
@@ -58,6 +58,8 @@
     "state_name_booting": "Bootin' up...",
     "state_name_unknown": "In the harbor",
     "state_name_disconnected": "Adrift in the vast ocean",
+    "power_state_suspending": "Catchin' forty winks",
+    "power_state_suspending_imminent": "Driftin' off to sleep soon...",
     "state_name_linking": "Joinin' forces with the app, arrr!",
     "state_desc_standby": "Shhh! Yer ship be takin' a nap",
     "state_desc_off": "Yer ship be as dead as Davy Jones' locker",


### PR DESCRIPTION
The firmware uses "suspending" as the terminal resting state while the scooter is asleep (there is no distinct 'suspended' state), so the suspending label is what's shown the entire time it's asleep. The existing strings read as an ongoing transition ('Suspending', 'Geht in Ruhezustand...'), making a fully-asleep scooter look stuck entering sleep.

Relabel power_state_suspending to a resting/asleep wording across locales (de, en, fr), and add the missing pirate strings to pi.json. nl was already correct ('In slaapstand'); en_GB inherits en via fallback. The _imminent strings already convey the transitional phase and are unchanged.
