### PR TITLE
Gate hibernate button on probed hibernate-for capability

### DIFF
--- a/lib/control_sheet.dart
+++ b/lib/control_sheet.dart
@@ -191,39 +191,64 @@ class _ControlSheetState extends State<ControlSheet> with TickerProviderStateMix
               ),
               SizedBox(width: 16),
               Expanded(
-                child: TextButton.icon(
-                  style: TextButton.styleFrom(
-                    backgroundColor: Theme.of(context).colorScheme.onSurface,
-                    foregroundColor: Theme.of(context).colorScheme.surface,
-                    padding: const EdgeInsets.symmetric(vertical: 16),
-                  ),
-                  onPressed: () async {
-                    final service = context.read<ScooterService>();
-                    if (service.identity.supportsHibernateFor == true) {
-                      final done = await showModalBottomSheet<bool>(
-                        context: context,
-                        showDragHandle: true,
-                        isScrollControlled: true,
-                        builder: (context) => const HibernateSheet(),
-                      );
-                      if (!context.mounted) return;
-                      // also close if the scooter disconnected while the sheet
-                      // was open: the disconnect listener above will have
-                      // popped the sheet instead of this control sheet
-                      if (done == true || !service.connected) {
-                        Navigator.of(context).pop();
-                      }
-                    } else {
-                      try {
-                        service.hibernate();
-                        Navigator.of(context).pop();
-                      } catch (e) {
-                        Fluttertoast.showToast(msg: e.toString());
-                      }
-                    }
+                child: Selector<ScooterService, bool?>(
+                  selector: (context, s) => s.identity.supportsHibernateFor,
+                  builder: (context, supportsHibernateFor, _) {
+                    // capability not probed yet: block the button so an
+                    // instant hibernate can't slip through before we know
+                    // whether a wake timer can be scheduled
+                    final probing = supportsHibernateFor == null;
+                    return TextButton.icon(
+                      style: TextButton.styleFrom(
+                        backgroundColor: Theme.of(context).colorScheme.onSurface,
+                        foregroundColor: Theme.of(context).colorScheme.surface,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                      ),
+                      onPressed: probing
+                          ? null
+                          : () async {
+                              final service = context.read<ScooterService>();
+                              if (supportsHibernateFor == true) {
+                                final done = await showModalBottomSheet<bool>(
+                                  context: context,
+                                  showDragHandle: true,
+                                  isScrollControlled: true,
+                                  builder: (context) => const HibernateSheet(),
+                                );
+                                if (!context.mounted) return;
+                                // also close if the scooter disconnected while the sheet
+                                // was open: the disconnect listener above will have
+                                // popped the sheet instead of this control sheet
+                                if (done == true || !service.connected) {
+                                  Navigator.of(context).pop();
+                                }
+                              } else {
+                                try {
+                                  service.hibernate();
+                                  Navigator.of(context).pop();
+                                } catch (e) {
+                                  Fluttertoast.showToast(msg: e.toString());
+                                }
+                              }
+                            },
+                      label: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(FlutterI18n.translate(context, "controls_hibernate")),
+                          if (probing) ...[
+                            const SizedBox(width: 8),
+                            const SizedBox(
+                              width: 14,
+                              height: 14,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                          ],
+                        ],
+                      ),
+                      icon: const Icon(Icons.nightlight_outlined),
+                    );
                   },
-                  label: Text(FlutterI18n.translate(context, "controls_hibernate")),
-                  icon: const Icon(Icons.nightlight_outlined),
                 ),
               ),
             ],

--- a/lib/domain/saved_scooter.dart
+++ b/lib/domain/saved_scooter.dart
@@ -21,6 +21,7 @@ class SavedScooter {
   String? _lastAddress;
   bool? _handlebarsLocked;
   bool? _isLibrescoot;
+  bool? _supportsHibernateFor;
   List<NavDestination>? _cachedDestinations;
 
   SavedScooter({
@@ -37,6 +38,7 @@ class SavedScooter {
     String? lastAddress,
     bool? handlebarsLocked,
     bool? isLibrescoot,
+    bool? supportsHibernateFor,
     List<NavDestination>? cachedDestinations,
   })  : _name = name ?? "Scooter Pro",
         _id = id,
@@ -51,6 +53,7 @@ class SavedScooter {
         _lastAddress = lastAddress,
         _handlebarsLocked = handlebarsLocked,
         _isLibrescoot = isLibrescoot,
+        _supportsHibernateFor = supportsHibernateFor,
         _cachedDestinations = cachedDestinations;
 
   set name(String name) {
@@ -115,6 +118,11 @@ class SavedScooter {
     updateSharedPreferences();
   }
 
+  set supportsHibernateFor(bool? supportsHibernateFor) {
+    _supportsHibernateFor = supportsHibernateFor;
+    updateSharedPreferences();
+  }
+
   set cachedDestinations(List<NavDestination>? cachedDestinations) {
     _cachedDestinations = cachedDestinations;
     updateSharedPreferences();
@@ -133,6 +141,7 @@ class SavedScooter {
   String? get lastAddress => _lastAddress;
   bool? get handlebarsLocked => _handlebarsLocked;
   bool? get isLibrescoot => _isLibrescoot;
+  bool? get supportsHibernateFor => _supportsHibernateFor;
   List<NavDestination>? get cachedDestinations => _cachedDestinations;
 
   BluetoothDevice get bluetoothDevice => BluetoothDevice.fromId(_id);
@@ -151,6 +160,7 @@ class SavedScooter {
         'lastAddress': _lastAddress,
         'handlebarsLocked': _handlebarsLocked,
         'isLibrescoot': _isLibrescoot,
+        'supportsHibernateFor': _supportsHibernateFor,
         'cachedDestinations': _cachedDestinations?.map((d) => d.toJson()).toList(),
       };
 
@@ -172,6 +182,7 @@ class SavedScooter {
       lastAuxSOC: map['lastAuxSOC'],
       handlebarsLocked: map['handlebarsLocked'],
       isLibrescoot: map['isLibrescoot'],
+      supportsHibernateFor: map['supportsHibernateFor'],
       cachedDestinations: (map['cachedDestinations'] as List<dynamic>?)
           ?.map((e) => NavDestination.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -173,6 +173,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
     identity.color = mostRecentScooter?.color;
     identity.lastLocation = mostRecentScooter?.lastLocation;
     identity.isLibrescoot = mostRecentScooter?.isLibrescoot;
+    identity.supportsHibernateFor = mostRecentScooter?.supportsHibernateFor;
     vehicle.handlebarsLocked = mostRecentScooter?.handlebarsLocked;
 
     // Load pending navigation from persistent storage
@@ -393,6 +394,9 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       // Set up this scooter as ours
       myScooter = attemptedScooter;
       identity.resetLsCapabilities();
+      // fall back to the cached capability until the probe resolves again
+      identity.supportsHibernateFor =
+          savedScooters[attemptedScooter.remoteId.toString()]?.supportsHibernateFor;
       _lsProbeGeneration++;
       addSavedScooter(myScooter!.remoteId.toString());
 
@@ -670,6 +674,11 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
     }
     if (generation != _lsProbeGeneration) return;
     identity.supportsHibernateFor = supportsHibernateFor;
+    // cache the capability so the next session doesn't wait for the probe
+    final probedScooterId = myScooter?.remoteId.toString();
+    if (probedScooterId != null && savedScooters.containsKey(probedScooterId)) {
+      savedScooters[probedScooterId]!.supportsHibernateFor = supportsHibernateFor;
+    }
     notifyListeners();
 
     bool? supportsScheduledHibernation;


### PR DESCRIPTION
## Problem

The capability probe (`_probeLsCapabilities`) is fire-and-forget after each connect, so `identity.supportsHibernateFor` stays `null` for a short window. The hibernate button branched on `== true`, treating "unknown" as "unsupported" — pressing hibernate right after connecting sent an instant `hibernate()` with no wake timer even on scooters that support `pm:hibernate-for`.

## Fix

- **Block the race in the UI:** while `supportsHibernateFor == null`, the hibernate button in the control sheet is disabled and shows a spinner next to its label. Once the probe resolves, it opens the wake-timer sheet or hibernates instantly as before.
- **Cache the capability per scooter:** `supportsHibernateFor` is now persisted on `SavedScooter` (same pattern as `isLibrescoot`), seeded at startup and on connect, and written back after each successful probe. The probe window only remains on the very first pairing with a scooter.

## Known edge cases

- If the nRF version read itself fails, the flags stay `null` and the button remains disabled until reconnect (same failure mode the existing librescoot-only UI already has).
- After a firmware downgrade, a stale cached `true` can offer the wake-timer sheet for a few seconds until the probe corrects it; `hibernateFor` would then fail with a toast. Same staleness tradeoff as the existing `isLibrescoot` cache.