### PR TITLE
Fix scooter visual drifting off-center when height-constrained

### DIFF
--- a/lib/scooter_visual.dart
+++ b/lib/scooter_visual.dart
@@ -195,8 +195,14 @@ class _ScooterVisualState extends State<ScooterVisual> {
           ),
         Padding(
           padding: const EdgeInsets.all(16.0),
-          child: SizedBox(
-            width: MediaQuery.of(context).size.width * 0.55,
+          child: ConstrainedBox(
+            // max-width instead of a tight width: when the available height is
+            // the limiting factor, AspectRatio must be free to shrink the width
+            // too, or the box gets squashed and the AnimatedCrossFade layers
+            // (which align topStart, unlike plain Images) drift off-center.
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width * 0.55,
+            ),
             child: AspectRatio(
               aspectRatio: _scooterAspectRatio,
               child: Stack(


### PR DESCRIPTION
## Problem

Since #152 the scooter visual can render shifted to the left instead of centered.

The `AspectRatio` box introduced there sits inside a `SizedBox` with a **tight** width (55 % of screen width). When the available height in the `Expanded` slot is less than `width × 1800/866` — the common case on phones, especially with the battery bars row visible — `AspectRatio` cannot shrink a tight width, so the box gets squashed vertically instead of keeping its ratio.

Inside the squashed box the layers disagree on alignment: plain `Image` layers (light ring, beam) letterbox with center alignment, but the scooter base lives in an `AnimatedCrossFade`, whose internal layout stack aligns its visible child topStart. The base image scales to full height with horizontal slack left over and gets pinned to the left edge, out of register with the ring/beam overlays.

## Fix

Use a max-width `ConstrainedBox` instead of a tight `SizedBox`, so `AspectRatio` is free to shrink the width when height-limited and always keeps the true 866:1800 box. Every layer then fills the box edge-to-edge with zero slack — nothing left to drift — while preserving what #152 was after (stable size from the first frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)