### PR TITLE
Recover from stale scanning and connection state after resume

### DIFF
--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -385,8 +385,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
         // automatically and does not expose a priority request.
         try {
           await attemptedScooter.requestMtu(247);
-          await attemptedScooter.requestConnectionPriority(
-              connectionPriorityRequest: ConnectionPriority.high);
+          await attemptedScooter.requestConnectionPriority(connectionPriorityRequest: ConnectionPriority.high);
         } catch (e) {
           log.warning("MTU/priority negotiation failed (continuing): $e");
         }
@@ -396,8 +395,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       myScooter = attemptedScooter;
       identity.resetLsCapabilities();
       // fall back to the cached capability until the probe resolves again
-      identity.supportsHibernateFor =
-          savedScooters[attemptedScooter.remoteId.toString()]?.supportsHibernateFor;
+      identity.supportsHibernateFor = savedScooters[attemptedScooter.remoteId.toString()]?.supportsHibernateFor;
       _lsProbeGeneration++;
       addSavedScooter(myScooter!.remoteId.toString());
 
@@ -1087,9 +1085,9 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       // isScanning event, leaving `scanning` stuck true — which disables
       // the manual reconnect button and blocks every automatic reconnect
       // path until the app is restarted.
-      if (scanning && !flutterBluePlus.isScanningNow) {
-        log.info("App resumed: clearing stale scanning flag");
-        scanning = false;
+      if (scanning != flutterBluePlus.isScanningNow) {
+        log.info("App resumed: resync scanning flag (cached: $scanning, platform: $flutterBluePlus.isScanningNow)");
+        scanning = flutterBluePlus.isScanningNow;
       }
 
       // The BLE link can also die during suspension without a disconnect
@@ -1098,8 +1096,8 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       if (connected && myScooter != null) {
         try {
           await myScooter!.readRssi();
-        } catch (e) {
-          log.info("App resumed: connection is stale, marking as disconnected");
+        } catch (e, stack) {
+          log.info("App resumed: connection is stale, marking as disconnected", e, stack);
           connected = false;
           state = ScooterState.disconnected;
         }

--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -1075,34 +1075,50 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
   bool get _connectionAttemptInFlight => scanning || _state == ScooterState.linking;
 
   void _handleAppResumedFromBackground() async {
-    // Only attempt reconnection if we have saved scooters and no connection
-    // exists or is being established right now
-    if (savedScooters.isNotEmpty && !connected && !_connectionAttemptInFlight) {
-      log.info("App resumed: attempting automatic reconnection");
+    if (savedScooters.isEmpty) return;
 
-      try {
-        // Small delay to let the app settle
-        await Future.delayed(const Duration(milliseconds: 500));
+    try {
+      // Small delay so the platform can deliver events that were queued
+      // while the app was suspended (disconnects, scan stops) before we
+      // judge any cached state
+      await Future.delayed(const Duration(milliseconds: 500));
 
-        // Conditions may have changed while settling (e.g. an in-flight
-        // attempt from startup finished connecting in the meantime)
-        if (connected || _connectionAttemptInFlight) {
-          log.info("App resumed: connection (attempt) appeared while settling, not restarting");
-          return;
+      // iOS kills an active scan during suspension without a final
+      // isScanning event, leaving `scanning` stuck true — which disables
+      // the manual reconnect button and blocks every automatic reconnect
+      // path until the app is restarted.
+      if (scanning && !flutterBluePlus.isScanningNow) {
+        log.info("App resumed: clearing stale scanning flag");
+        scanning = false;
+      }
+
+      // The BLE link can also die during suspension without a disconnect
+      // event ever reaching us, so probe the link instead of trusting the
+      // cached connected flag.
+      if (connected && myScooter != null) {
+        try {
+          await myScooter!.readRssi();
+        } catch (e) {
+          log.info("App resumed: connection is stale, marking as disconnected");
+          connected = false;
+          state = ScooterState.disconnected;
         }
+      }
 
+      if (!connected && !_connectionAttemptInFlight) {
+        log.info("App resumed: attempting automatic reconnection");
         // Try to reconnect to the last known scooter
         start();
-      } catch (e, stack) {
-        log.warning(
-          "Error during automatic reconnection on app resume",
-          e,
-          stack,
+      } else {
+        log.info(
+          "App resumed: no reconnection needed (connected: $connected, scanning: $scanning, saved scooters: ${savedScooters.length})",
         );
       }
-    } else {
-      log.info(
-        "App resumed: no reconnection needed (connected: $connected, scanning: $scanning, saved scooters: ${savedScooters.length})",
+    } catch (e, stack) {
+      log.warning(
+        "Error during automatic reconnection on app resume",
+        e,
+        stack,
       );
     }
   }


### PR DESCRIPTION
## Problem

Addresses the community report from iOS users: *"An alle die iOS nutzen, müsst ihr die App auch immer wieder neustarten damit das Entsperren oder Runterfahren funktioniert?"*

Two ways the app comes back from iOS suspension wedged until a force-restart:

1. **Stale `scanning == true`** — iOS kills an active scan during suspension without a final `isScanning` event. After resume, `scanning` stays true forever, which disables the manual reconnect button and blocks both the resume handler and auto-restart. No way out except restarting the app.
2. **Stale `connected == true`** — the BLE link dies during suspension but the disconnect event is never delivered. The app looks connected while unlock/lock writes silently fail against a dead link (the standby-unlock path only catches `HandlebarLockException`).

## Fix

On resume (after the settle delay, so queued platform events land first):

- Re-sync `scanning` with the platform's `isScanningNow` and clear the wedge if they disagree.
- Probe an allegedly alive connection with a cheap `readRssi` call instead of trusting the cached flag; on failure, reset to disconnected and reconnect via `start()`.

## Notes

Stacked on #153 (same function is touched); base is set to that branch and this PR should be rebased/retargeted onto `main` once #153 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)