### PR TITLE
Adopt the iOS UIScene lifecycle

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,17 +1,18 @@
 import Flutter
 import UIKit
 import flutter_background_service_ios
-import flutter_sharing_intent
 import home_widget
 import workmanager_apple
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
 
+    // BGTaskScheduler identifiers have to be claimed before launch finishes, so
+    // this setup stays here instead of moving to the implicit engine callback.
     SwiftFlutterBackgroundServicePlugin.taskIdentifier = "de.freal.unustasis.background"
 
     WorkmanagerPlugin.setPluginRegistrantCallback { registry in
@@ -30,17 +31,16 @@ import workmanager_apple
       }
     }
 
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
-  override func application(
-    _ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]
-  ) -> Bool {
-    let sharingIntent = SwiftFlutterSharingIntentPlugin.instance
-    if sharingIntent.hasSameSchemePrefix(url: url) {
-      return sharingIntent.application(app, open: url, options: options)
-    }
-    return super.application(app, open: url, options: options)
+  // Under the UIScene lifecycle the engine is created after UIKit's
+  // didFinishLaunchingWithOptions returns, so plugins register here instead.
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
+
+  // Incoming share URLs used to be routed here by hand. UIKit no longer calls
+  // application(_:open:options:) on a scene-based app; FlutterSceneDelegate now
+  // forwards scene(_:openURLContexts:) to flutter_sharing_intent for us.
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -29,6 +29,8 @@
 		<string>????</string>
 		<key>CFBundleVersion</key>
 		<string>$(FLUTTER_BUILD_NUMBER)</string>
+		<key>FlutterDeepLinkingEnabled</key>
+		<false/>
 		<key>ITSAppUsesNonExemptEncryption</key>
 		<false/>
 		<key>LSApplicationQueriesSchemes</key>
@@ -68,6 +70,27 @@
 		<string>Location is required to remember where your scooter was last seen</string>
 		<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 		<string>Location is required to remember where your scooter was last seen and to provide location-based features in the background</string>
+		<key>UIApplicationSceneManifest</key>
+		<dict>
+			<key>UIApplicationSupportsMultipleScenes</key>
+			<false/>
+			<key>UISceneConfigurations</key>
+			<dict>
+				<key>UIWindowSceneSessionRoleApplication</key>
+				<array>
+					<dict>
+						<key>UISceneClassName</key>
+						<string>UIWindowScene</string>
+						<key>UISceneDelegateClassName</key>
+						<string>FlutterSceneDelegate</string>
+						<key>UISceneConfigurationName</key>
+						<string>flutter</string>
+						<key>UISceneStoryboardFile</key>
+						<string>Main</string>
+					</dict>
+				</array>
+			</dict>
+		</dict>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 		<true/>
 		<key>UIBackgroundModes</key>


### PR DESCRIPTION
Apple requires UIKit apps built against the post-iOS 26 SDK to use the UIScene
lifecycle or they won't launch. Our AppDelegate is customised, so `flutter run`
can't auto-migrate it and only prints the warning. This does the migration by
hand.

Without this, nothing ships to the App Store.

### Changes

- Add `UIApplicationSceneManifest` to Info.plist, pointing at the stock
  `FlutterSceneDelegate` with the existing Main storyboard.
- Conform AppDelegate to `FlutterImplicitEngineDelegate` and register plugins
  from `didInitializeImplicitFlutterEngine`. Under UIScene the implicit engine
  is created after UIKit's `didFinishLaunchingWithOptions` returns, so
  registering there would be too early.
- Keep the BGTaskScheduler setup (flutter_background_service identifier and the
  Workmanager periodic task) in `didFinishLaunchingWithOptions` - those
  identifiers still have to be claimed before launch completes. That is enough
  for Workmanager but not for flutter_background_service, see the blocker below.
- Drop the hand-rolled `application(_:open:options:)` override. UIKit no longer
  calls it on a scene-based app; incoming share URLs now arrive via
  `scene(_:openURLContexts:)`, which `FlutterSceneDelegate` forwards to
  flutter_sharing_intent through the engine's application-delegate fallback.
  Cold starts are covered too, since the engine synthesises launch options from
  the scene's connection options.
- Set `FlutterDeepLinkingEnabled` to false. The scene willConnect path relays
  unhandled URLs back to the system, which would bounce our own `SharingMedia-*`
  scheme back into the app on a cold-start share. We have no Flutter-side
  routing (`MaterialApp` with only `home:`, no named routes, no
  `onGenerateRoute`), so opting out keeps the previous behaviour.

### Verified against Flutter 3.41.9

No Xcode available here, so this was checked statically against the engine
sources shipped with the pinned SDK (framework `00b0c91f06`, engine
`9161402dc0`).

- `FlutterImplicitEngineDelegate` and `FlutterImplicitEngineBridge` are declared
  in `shell/platform/darwin/ios/framework/Headers/FlutterEngine.h:456-491`, both
  exported through `Headers/Flutter.h`. The required method is
  `- (void)didInitializeImplicitFlutterEngine:(NSObject<FlutterImplicitEngineBridge>*)engineBridge`
  and the bridge vends `pluginRegistry`.
- The Swift signature we use is byte-for-byte the one in the tool's own
  auto-migrator (`flutter_tools/lib/src/migrations/uiscene_migration.dart:184`)
  and the new-project template
  (`flutter_tools/templates/app/ios.tmpl/Runner/AppDelegate.swift:13`).
- `FlutterSceneDelegate` is a public ObjC class
  (`Headers/FlutterSceneDelegate.h:20`), so naming it unqualified in the plist
  is right; no `$(PRODUCT_MODULE_NAME).` prefix.
- Our `UIApplicationSceneManifest` dict matches the JSON the auto-migrator
  inserts (`uiscene_migration.dart:276-292`) key for key.
- The engine calls back through `-[FlutterEngine performImplicitEngineCallback]`
  (`Source/FlutterEngine.mm:954-962`), which checks
  `conformsToProtocol:@protocol(FlutterImplicitEngineDelegate)` on the app
  delegate. That conformance is load-bearing for more than plugin registration:
  `FlutterViewController.mm:308-329` only replays the deferred launch events to
  plugins when that callback fired.
- Share URL delivery does work the way the bullet above claims.
  `FlutterSceneDelegate scene:openURLContexts:` reaches
  `FlutterPluginSceneLifeCycleDelegate` (`FlutterSceneLifeCycle.mm:289-311`),
  which, when no scene-aware plugin claims the event, calls
  `sceneFallbackOpenURLContexts:` and from there the plugin's legacy
  `application:openURL:options:`
  (`FlutterPluginAppLifeCycleDelegate.mm:498-527`). flutter_sharing_intent
  registers via `addApplicationDelegate` and does not conform to
  `FlutterSceneLifeCycleDelegate`, so it lands in that fallback. Cold start goes
  through `sceneWillConnectFallback:`, which synthesises
  `UIApplicationLaunchOptionsURLKey` from the connection options
  (`FlutterPluginAppLifeCycleDelegate.mm:156-220`).
- `FlutterDeepLinkingEnabled` false is checked in
  `FlutterSceneLifeCycle.mm:456-465` before the `openURL:` throwback, so the
  bounce really is suppressed.
- Foreground/background plugin callbacks (local_auth's
  `applicationDidBecomeActive`, flutter_background_service's
  `applicationDidEnterBackground`) still arrive via the scene fallbacks in
  `FlutterPluginAppLifeCycleDelegate.mm:270-380`. Dart's `AppLifecycleState`
  also still fires, because `FlutterViewController` keeps observing the
  `UIApplication*` notifications for non-extension bundles
  (`FlutterViewController.mm:380-384`), and UIKit keeps posting those under
  UIScene.

### Blocker: flutter_background_service_ios is not UIScene-ready

flutter_background_service_ios 5.0.3 calls
`BGTaskScheduler.shared.register(forTaskWithIdentifier:)` from its own
`application(_:didFinishLaunchingWithOptions:)`
(`SwiftFlutterBackgroundServicePlugin.swift:36-42`, via `registerTaskIdentifier`).
Under UIScene that method is no longer called by UIKit; Flutter replays it from
`scene:willConnectToSession:options:`, after UIKit's launch has finished. The
migration guide names `BGTaskScheduler.registerForTaskWithIdentifier:...`
specifically as an API that cannot be deferred, and tells plugin authors to drop
the delegate call and expose a public method the app calls from its own
`didFinishLaunchingWithOptions` instead.

Setting `SwiftFlutterBackgroundServicePlugin.taskIdentifier` in
`didFinishLaunchingWithOptions` (which this PR keeps) is not enough: it only
stores the string, the actual `register` still happens in the deferred
callback. Calling `SwiftFlutterBackgroundServicePlugin.registerTaskIdentifier`
early ourselves does not fix it either, since the plugin's late call still runs
afterwards.

Upstream issue is open and untouched since February:
ekasetiawans/flutter_background_service#534. 5.0.3 is the newest published
version, so there is no upgrade out of it.

Workmanager is fine: `WorkmanagerPlugin.registerPeriodicTask` is called directly
from our `didFinishLaunchingWithOptions` (the pattern the guide recommends), and
workmanager_apple has no launch-time delegate hook of its own.

Needs a decision:

1. Test on device first. If iOS only logs and returns false rather than raising
   `NSInternalInconsistencyException`, the worst case is that the
   `de.freal.unustasis.background` BGAppRefreshTask never fires, and the widget
   refresh (Workmanager) still works.
2. If it does throw, fork flutter_background_service_ios behind a
   `dependency_override` with the `register` call moved out of the delegate
   method, matching what background_fetch did for the same problem.

Worth settling before this merges. If iOS does raise, the app crashes on every
cold start and the migration is unshippable until the plugin is patched.

### Share extension is half-removed

Current state, for the record:

- `ios/Share Extension/` is intact on disk, including our customised
  `FSIShareViewController` and `ShareViewController`.
- The `Share Extension` PBXNativeTarget still exists and is still in the
  project's `targets` list (`project.pbxproj:333-352`, `413-419`).
- 156f54e dropped the Runner target dependency and the
  `Embed Foundation Extensions` entry, so `Runner.app` no longer contains the
  appex. Two orphan objects were left behind, a `PBXBuildFile` at
  `project.pbxproj:21` and a `PBXTargetDependency` at `project.pbxproj:655`,
  both unreferenced and harmless.
- b2a5573 commented out the Podfile target (`ios/Podfile:49-51`), so
  `pod install` no longer generates `Pods-Share Extension.*.xcconfig`. The
  target's build configs still point their `baseConfigurationReference` at those
  files, so building that target directly now fails. The Runner scheme only
  builds Runner and RunnerTests, so `flutter build ios` is unaffected.

Consequence for this PR: with no appex in the bundle, the app never appears in
the iOS share sheet, so nothing ever produces a `SharingMedia-*` URL. The
`scene(_:openURLContexts:)` path is correct but currently unreachable on iOS.
Worth noting that even with the extension restored it is the secondary path.
`redirectToHostApp()` uses `extensionContext.open`, which is unreliable from a
share extension, which is why `lib/service/sharing_handler.dart:49-67` also
picks the payload up out of the App Group on `AppLifecycleState.resumed`. That
resume path is unaffected by this migration.

Android sharing is independent and unaffected: it comes in through the
`android.intent.action.SEND` / `text/*` intent-filter on `.MainActivity`
(`android/app/src/main/AndroidManifest.xml:29-33`), read by the plugin's Android
side.

So: `flutter_sharing_intent` has to stay in pubspec.yaml regardless. Dropping it
would take out Android sharing and all of `lib/service/sharing_handler.dart`.
The open question is only the iOS half, restore or delete, and that is a
separate PR either way.

### Deployment targets are inconsistent

Not touched here. Mapped for whoever picks it up:

| Scope | Debug | Release | Profile |
| --- | --- | --- | --- |
| Project (PBXProject) | 13.0 | 13.0 | 13.0 |
| Runner | 15.6 | 15.6 | 15.6 |
| RunnerTests | unset, inherits 13.0 | unset | unset |
| ScooterWidgetExtension | 26.0 | 26.0 | 26.0 |
| Share Extension | 15.6 | 15.6 | 15.6 |

`ios/Podfile:2` says `platform :ios, '14.0'`, and
`ios/Flutter/AppFrameworkInfo.plist` says `MinimumOSVersion` 14.0.

The one that actually costs something is the widget at 26.0, which makes the
home screen widget unavailable on anything below iOS 26 while the app itself
ships at 15.6. It reads like the Xcode 26 default from when the target was
created (`CreatedOnToolsVersion = 26.0`). The widget's real floor is 17.0:
`ios/ScooterWidget/ScooterWidget.swift:140` uses `.contentMarginsDisabled()`
unguarded and line 122 guards `.containerBackground` with
`#available(iOS 17.0, *)`. Nothing in there needs 26.

Suggested coherent set, if someone wants to take it:

- Project level 15.6, matching what Runner already ships.
- Runner 15.6, unchanged.
- RunnerTests left inheriting, which then stops linking 14.0 pods against a
  13.0 target.
- ScooterWidgetExtension 17.0.
- Podfile `platform :ios, '15.6'`.
- Share Extension 15.6 if it comes back, otherwise it goes away with the target.

### Test plan

Everything below needs a real device; none of it can be checked on CI.

Launch and lifecycle:

- [ ] Cold start, app launches and reaches the scooter screen
- [ ] Console is free of `NSInternalInconsistencyException` around
      BGTaskScheduler at launch (see the blocker above, this is the one that
      decides whether the PR is shippable as-is)
- [ ] Console is free of the engine's "The UIApplicationDelegate is setting up
      the UIWindow and UIWindow.rootViewController at launch" warning
- [ ] Background, resume, BLE reconnect still works
- [ ] Lock the screen and unlock, no spurious reconnect

Plugins that go through the scene fallbacks:

- [ ] Home screen widget lock/unlock round-trips (home_widget
      `application:openURL:options:` via `sceneFallbackOpenURLContexts:`)
- [ ] Tapping the widget cold-starts the app and the action still lands
      (home_widget launch options via `sceneWillConnectFallback:`)
- [ ] The 20 minute Workmanager widget refresh still fires
- [ ] `de.freal.unustasis.background` BGAppRefreshTask still fires, or is
      confirmed dead, and that is an accepted regression
- [ ] Local notification actions (lock, unlock, open seat) still work from the
      notification shade
- [ ] Biometric unlock still works, local_auth relies on
      `applicationDidBecomeActive` coming through the scene fallback

Sharing, only meaningful if the extension is restored first:

- [ ] Share a destination into the app from Maps on a cold start
- [ ] Share a destination while the app is already running
- [ ] Confirm no share sheet round-trip loop, which is what
      `FlutterDeepLinkingEnabled` false is there to prevent

Android regression pass, since the Dart side of sharing is shared:

- [ ] Share a location from Maps into the app, cold and warm
