### PR TITLE
Close extended-command response races and the duplicate ScooterService

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -91,40 +91,44 @@ final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 class _MyAppState extends State<MyApp> {
   SharingHandler? _sharingHandler;
-
-  @override
-  void initState() {
-    super.initState();
-    // SharingHandler is initialized in didChangeDependencies
-    // where the Provider context is available
-    scooterService.addListener(() async {
-      passToWidget(
-        connected: scooterService.connected,
-        lastPing: scooterService.identity.lastPing,
-        scooterState: scooterService.state,
-        primarySOC: scooterService.battery.primarySOC,
-        secondarySOC: scooterService.battery.secondarySOC,
-        scooterName: scooterService.identity.name,
-        scooterColor: scooterService.identity.color,
-        lastLocation: scooterService.identity.lastLocation,
-        seatClosed: scooterService.vehicle.seatClosed,
-        scooterLocked: scooterService.vehicle.handlebarsLocked,
-        scooterId: scooterService.myScooter?.remoteId.toString(),
-      );
-    });
-  }
+  ScooterService? _scooterService;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (_sharingHandler == null) {
+      // Bind to the Provider's ScooterService, not the background service's
+      // global. Touching that global from the foreground isolate constructs a
+      // second ScooterService here (top-level fields are lazily initialized
+      // per isolate), with its own location, RSSI and refresh timers, and it
+      // then reports state the UI never drives.
       final service = Provider.of<ScooterService>(context, listen: false);
+      _scooterService = service;
       _sharingHandler = SharingHandler(
         navigatorKey: navigatorKey,
         service: service,
       );
       _sharingHandler!.init();
+      service.addListener(_pushStateToWidget);
     }
+  }
+
+  void _pushStateToWidget() {
+    final service = _scooterService;
+    if (service == null) return;
+    passToWidget(
+      connected: service.connected,
+      lastPing: service.identity.lastPing,
+      scooterState: service.state,
+      primarySOC: service.battery.primarySOC,
+      secondarySOC: service.battery.secondarySOC,
+      scooterName: service.identity.name,
+      scooterColor: service.identity.color,
+      lastLocation: service.identity.lastLocation,
+      seatClosed: service.vehicle.seatClosed,
+      scooterLocked: service.vehicle.handlebarsLocked,
+      scooterId: service.myScooter?.remoteId.toString(),
+    );
   }
 
   @override
@@ -192,6 +196,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
+    _scooterService?.removeListener(_pushStateToWidget);
     _sharingHandler?.dispose();
     super.dispose();
   }

--- a/lib/service/ble_commands.dart
+++ b/lib/service/ble_commands.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:latlong2/latlong.dart';
@@ -28,12 +29,61 @@ Future<T> _withExtendedChannel<T>(Future<T> Function() action) {
   return result;
 }
 
+/// Thrown when the scooter's reply to an extended command doesn't have the
+/// shape we expect, so an error reply can be told apart from a valid one.
+class ExtendedResponseFormatException implements Exception {
+  final String message;
+  const ExtendedResponseFormatException(this.message);
+
+  @override
+  String toString() => "ExtendedResponseFormatException: $message";
+}
+
+/// Buffers the extended response characteristic's notifications.
+///
+/// `onValueReceived` is a broadcast stream, so anything emitted while nobody
+/// is subscribed is dropped. Constructing this before writing the command
+/// closes the window between the write and the read: responses that land in
+/// it are queued on a single-subscription controller and delivered as soon as
+/// the caller starts reading, instead of being lost to a 10 second timeout.
+@visibleForTesting
+class ExtendedResponseListener {
+  final StreamController<String> _buffer = StreamController<String>();
+  late final StreamSubscription<List<int>> _subscription;
+
+  ExtendedResponseListener(Stream<List<int>> source) {
+    _subscription = source.listen(
+      (value) {
+        if (value.isEmpty || _buffer.isClosed) return;
+        _buffer.add(ascii.decode(value).replaceAll('\x00', ''));
+      },
+      onError: (Object e, StackTrace s) {
+        if (!_buffer.isClosed) _buffer.addError(e, s);
+      },
+    );
+  }
+
+  /// Decoded responses, oldest first.
+  Stream<String> get responses => _buffer.stream;
+
+  Future<void> cancel() async {
+    await _subscription.cancel();
+    // Deliberately not awaited: closing a single-subscription controller that
+    // was never listened to (e.g. the command write threw) never completes.
+    if (!_buffer.isClosed) unawaited(_buffer.close());
+  }
+}
+
 /// Reads a counted list from an extended response [stream].
 ///
 /// Expects the first message to carry the count as its last colon-separated
 /// segment (e.g. `keycard:count:3`), followed by that many entry messages.
 /// [parseEntry] converts each entry message to [T]; returning null skips it.
-Future<List<T>> _readExtendedList<T>(
+///
+/// Throws [ExtendedResponseFormatException] when the first message carries no
+/// parseable count, so an error reply can't pass itself off as an empty list.
+@visibleForTesting
+Future<List<T>> readExtendedList<T>(
   Stream<String> stream,
   T? Function(String msg) parseEntry,
 ) async {
@@ -41,7 +91,11 @@ Future<List<T>> _readExtendedList<T>(
   int? count;
   await for (final msg in stream) {
     if (count == null) {
-      count = int.tryParse(msg.split(':').last) ?? 0;
+      final parsed = int.tryParse(msg.split(':').last);
+      if (parsed == null) {
+        throw ExtendedResponseFormatException("expected a count, got '$msg'");
+      }
+      count = parsed;
       if (count == 0) break;
     } else {
       final entry = parseEntry(msg);
@@ -50,6 +104,18 @@ Future<List<T>> _readExtendedList<T>(
     }
   }
   return results;
+}
+
+/// Turns notifications on for the extended response characteristic unless
+/// they're already on.
+///
+/// `isNotifying` is derived from the cached CCCD value, which flutter_blue_plus
+/// clears on disconnect, so the subscription lives for exactly one connection.
+/// Toggling it per command cost two extra CCCD writes each time and dropped
+/// any response that arrived while notify was off.
+Future<void> _ensureExtendedNotify(BluetoothCharacteristic resp) async {
+  if (resp.isNotifying) return;
+  await resp.setNotifyValue(true);
 }
 
 // Maximum payload for the extended command characteristic. The basic command
@@ -117,19 +183,16 @@ Future<String?> _sendLsExtendedCommandUnguarded(
     throw "Extended command characteristics not available";
   }
 
-  await resp.setNotifyValue(true);
+  await _ensureExtendedNotify(resp);
+  final listener = ExtendedResponseListener(resp.onValueReceived);
   try {
     await sendCommand(scooter, repo, command, characteristic: cmd, allowLongWrite: true);
-    return await resp.onValueReceived
-        .where((v) => v.isNotEmpty)
-        .map((v) => ascii.decode(v).replaceAll('\x00', ''))
-        .timeout(const Duration(seconds: 10), onTimeout: (sink) => sink.close())
-        .first;
-  } on StateError {
+    return await listener.responses.first.timeout(const Duration(seconds: 10));
+  } on TimeoutException {
     log.warning("sendLsExtendedCommand: timeout waiting for response to '$command'");
     return null;
   } finally {
-    await resp.setNotifyValue(false);
+    await listener.cancel();
   }
 }
 
@@ -406,14 +469,12 @@ Future<List<NavDestination>> listFavDestinationsCommand(
     throw "Extended command characteristics not available";
   }
 
-  await resp.setNotifyValue(true);
+  await _ensureExtendedNotify(resp);
+  final listener = ExtendedResponseListener(resp.onValueReceived);
   try {
     await sendCommand(scooter, repo, "nav:fav:list", characteristic: cmd);
-    final stream = resp.onValueReceived
-        .where((v) => v.isNotEmpty)
-        .map((v) => ascii.decode(v).replaceAll('\x00', ''))
-        .timeout(const Duration(seconds: 10));
-    return await _readExtendedList(stream, (msg) {
+    final stream = listener.responses.timeout(const Duration(seconds: 10));
+    return await readExtendedList(stream, (msg) {
       // format: nav:fav:<id>:lat,lon[,name]
       final parts = msg.split(":");
       if (parts.length < 4) return null;
@@ -430,7 +491,7 @@ Future<List<NavDestination>> listFavDestinationsCommand(
       );
     });
   } finally {
-    await resp.setNotifyValue(false);
+    await listener.cancel();
   }
 });
 
@@ -486,7 +547,7 @@ Future<int?> countKeycardsCommand(
 }
 
 /// Lists keycards registered on the scooter.
-/// Expects: keycard:count:<n>, then one keycard:card:<uid> message per entry.
+/// Expects: `keycard:count:<n>`, then one `keycard:card:<uid>` message per entry.
 Future<List<String>> listKeycardsCommand(
   BluetoothDevice? scooter,
   CharacteristicRepository repo,
@@ -501,14 +562,12 @@ Future<List<String>> listKeycardsCommand(
     throw "Extended command characteristics not available";
   }
 
-  await resp.setNotifyValue(true);
+  await _ensureExtendedNotify(resp);
+  final listener = ExtendedResponseListener(resp.onValueReceived);
   try {
     await sendCommand(scooter, repo, "keycard:list", characteristic: cmd);
-    final stream = resp.onValueReceived
-        .where((v) => v.isNotEmpty)
-        .map((v) => ascii.decode(v).replaceAll('\x00', ''))
-        .timeout(const Duration(seconds: 10));
-    return await _readExtendedList(stream, (msg) {
+    final stream = listener.responses.timeout(const Duration(seconds: 10));
+    return await readExtendedList(stream, (msg) {
       // format: keycard:card:<uid>
       final parts = msg.split(":");
       if (parts.length >= 3 && parts[0] == "keycard" && parts[1] == "card") {
@@ -519,7 +578,7 @@ Future<List<String>> listKeycardsCommand(
       return null;
     });
   } finally {
-    await resp.setNotifyValue(false);
+    await listener.cancel();
   }
 });
 
@@ -651,16 +710,13 @@ Future<Set<String>> getPmCapabilitiesCommand(
     throw "Extended command characteristics not available";
   }
 
-  await resp.setNotifyValue(true);
+  await _ensureExtendedNotify(resp);
+  final listener = ExtendedResponseListener(resp.onValueReceived);
   try {
     await sendCommand(scooter, repo, "cap:pm", characteristic: cmd);
-    final stream = resp.onValueReceived
-        .where((v) => v.isNotEmpty)
-        .map((v) => ascii.decode(v).replaceAll('\x00', ''))
-        .timeout(const Duration(seconds: 10));
+    final stream = listener.responses.timeout(const Duration(seconds: 10));
     // format: cap:pm:count:<n>, then cap:pm:<command>[ <args>] per entry.
-    // Error responses fail the count parse and yield an empty list.
-    final entries = await _readExtendedList(stream, (msg) {
+    final entries = await readExtendedList(stream, (msg) {
       if (!msg.startsWith("cap:pm:")) return null;
       final name = msg.substring("cap:pm:".length).split(" ").first;
       return name.isNotEmpty ? name : null;
@@ -669,8 +725,13 @@ Future<Set<String>> getPmCapabilitiesCommand(
   } on TimeoutException {
     log.info("getPmCapabilitiesCommand: timeout, assuming no pm capabilities");
     return <String>{};
+  } on ExtendedResponseFormatException catch (e) {
+    // Firmware without the capability query answers with an error string
+    // rather than a count. Treat that as "no capabilities", but log it.
+    log.info("getPmCapabilitiesCommand: unparseable reply, assuming no pm capabilities ($e)");
+    return <String>{};
   } finally {
-    await resp.setNotifyValue(false);
+    await listener.cancel();
   }
 });
 

--- a/test/service/ble_commands_test.dart
+++ b/test/service/ble_commands_test.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:unustasis/service/ble_commands.dart';
+
+List<int> enc(String s) => ascii.encode(s);
+
+void main() {
+  group('readExtendedList', () {
+    test('reads a counted list', () async {
+      final stream = Stream.fromIterable([
+        'keycard:count:2',
+        'keycard:card:aabb',
+        'keycard:card:ccdd',
+      ]);
+      final got = await readExtendedList(stream, (msg) => msg.split(':').last);
+      expect(got, ['aabb', 'ccdd']);
+    });
+
+    test('stops at the announced count and ignores trailing messages', () async {
+      final stream = Stream.fromIterable([
+        'keycard:count:1',
+        'keycard:card:aabb',
+        'keycard:card:ccdd',
+      ]);
+      final got = await readExtendedList(stream, (msg) => msg.split(':').last);
+      expect(got, ['aabb']);
+    });
+
+    test('returns empty on a genuine zero count', () async {
+      final stream = Stream.fromIterable(['keycard:count:0']);
+      final got = await readExtendedList(stream, (msg) => msg);
+      expect(got, isEmpty);
+    });
+
+    test('throws on an unparseable count instead of reporting zero items', () async {
+      final stream = Stream.fromIterable(['error:unknown command']);
+      expect(
+        readExtendedList(stream, (msg) => msg),
+        throwsA(isA<ExtendedResponseFormatException>()),
+      );
+    });
+
+    test('throws on an error reply that ends in a non-numeric segment', () async {
+      final stream = Stream.fromIterable(['cap:error:unsupported']);
+      expect(
+        readExtendedList(stream, (msg) => msg),
+        throwsA(isA<ExtendedResponseFormatException>()),
+      );
+    });
+
+    test('a zero count and a parse failure are distinguishable', () async {
+      final zero = await readExtendedList(Stream.fromIterable(['cap:pm:count:0']), (msg) => msg);
+      expect(zero, isEmpty);
+
+      Object? thrown;
+      try {
+        await readExtendedList(Stream.fromIterable(['cap:pm:error']), (msg) => msg);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown, isA<ExtendedResponseFormatException>());
+      expect(thrown.toString(), contains('cap:pm:error'));
+    });
+
+    test('skips entries the parser rejects', () async {
+      final stream = Stream.fromIterable([
+        'keycard:count:2',
+        'garbage',
+        'keycard:card:aabb',
+        'keycard:card:ccdd',
+      ]);
+      final got = await readExtendedList(
+        stream,
+        (msg) => msg.startsWith('keycard:card:') ? msg.split(':').last : null,
+      );
+      expect(got, ['aabb', 'ccdd']);
+    });
+
+    test('returns what it got when the stream ends early', () async {
+      final stream = Stream.fromIterable([
+        'keycard:count:3',
+        'keycard:card:aabb',
+      ]);
+      final got = await readExtendedList(stream, (msg) => msg.split(':').last);
+      expect(got, ['aabb']);
+    });
+  });
+
+  group('ExtendedResponseListener', () {
+    test('delivers responses emitted before the caller starts reading', () async {
+      final source = StreamController<List<int>>.broadcast();
+      final listener = ExtendedResponseListener(source.stream);
+
+      // The response lands in the window between the command write and the
+      // read. On a bare broadcast stream this would be dropped.
+      source.add(enc('nav:ok'));
+      await Future.delayed(Duration.zero);
+
+      expect(await listener.responses.first.timeout(const Duration(seconds: 1)), 'nav:ok');
+      await listener.cancel();
+      await source.close();
+    });
+
+    test('preserves order across the write window', () async {
+      final source = StreamController<List<int>>.broadcast();
+      final listener = ExtendedResponseListener(source.stream);
+
+      source.add(enc('keycard:count:2'));
+      source.add(enc('keycard:card:aabb'));
+      await Future.delayed(Duration.zero);
+      source.add(enc('keycard:card:ccdd'));
+
+      final got = await readExtendedList(
+        listener.responses.timeout(const Duration(seconds: 1)),
+        (msg) => msg.split(':').last,
+      );
+      expect(got, ['aabb', 'ccdd']);
+      await listener.cancel();
+      await source.close();
+    });
+
+    test('drops empty notifications and strips NUL padding', () async {
+      final source = StreamController<List<int>>.broadcast();
+      final listener = ExtendedResponseListener(source.stream);
+
+      source.add(<int>[]);
+      source.add([...enc('pm:ok'), 0, 0, 0]);
+      await Future.delayed(Duration.zero);
+
+      expect(await listener.responses.first.timeout(const Duration(seconds: 1)), 'pm:ok');
+      await listener.cancel();
+      await source.close();
+    });
+
+    test('cancel completes even when nothing ever read the responses', () async {
+      final source = StreamController<List<int>>.broadcast();
+      final listener = ExtendedResponseListener(source.stream);
+      source.add(enc('nav:ok'));
+      await Future.delayed(Duration.zero);
+
+      await listener.cancel().timeout(const Duration(seconds: 1));
+      await source.close();
+    });
+
+    test('stops buffering once cancelled', () async {
+      final source = StreamController<List<int>>.broadcast();
+      final listener = ExtendedResponseListener(source.stream);
+      await listener.cancel();
+
+      source.add(enc('nav:ok'));
+      await Future.delayed(Duration.zero);
+      expect(source.hasListener, isFalse);
+      await source.close();
+    });
+  });
+}


### PR DESCRIPTION
Three response races on the extended-command channel, plus a duplicate
ScooterService in the foreground isolate. All found while debugging apparent
scooter-side BLE instability that turned out to be app-side.

### Changes

**Listener attached before the write.** The four extended-command helpers
subscribed to `resp.onValueReceived` after sending the command, on a broadcast
stream, so a reply landing in that window was dropped and cost a 10 second
timeout. A new `ExtendedResponseListener` (`ble_commands.dart:41`) subscribes
first and buffers into a single-subscription controller. Applied to
`_sendLsExtendedCommandUnguarded`, `listFavDestinationsCommand`,
`listKeycardsCommand` and `getPmCapabilitiesCommand`.

**Notify is connection-scoped instead of per-command.** Notify on 9a590402 was
toggled on and off around every command: two extra CCCD writes each time, and
any response arriving while it was off was lost. `_ensureExtendedNotify`
(`:109`) enables it once when `!resp.isNotifying` and nothing turns it off.
Confirmed against flutter_blue_plus 1.34.5 that `isNotifying` reads a cache
cleared on disconnect, so a reconnect re-enables on the first command. Nothing
outside `ble_commands.dart` touches notify on that characteristic.

**A count that fails to parse is no longer read as zero.** `readExtendedList`
threw the parse result away and returned an empty list, so a malformed or error
response looked like a successful "no items" answer with no error and no delay.
It now throws `ExtendedResponseFormatException`. `getPmCapabilitiesCommand`
catches it to keep its documented empty-set-on-old-firmware behaviour; the two
list commands let it propagate to call sites that already show an error.

**One ScooterService in the foreground isolate.** `bg_service.dart:27` is a
top-level field, which Dart initialises lazily per isolate, and
`_MyAppState.initState` read it, constructing a second ScooterService alongside
the Provider one. Each carried its own 20s location timer, 3s rssi timer, 10s
refresh timer and isScanning subscription. The foreground copy never connects,
so its `notifyListeners` pushed widget updates carrying `connected: false` and
stale cache against the background isolate's real ones. The listener moved to
`didChangeDependencies` bound to the Provider instance, with `removeListener` in
`dispose`. `scooter_service.dart` was not touched.

### Test plan

- [x] `flutter analyze` clean
- [x] 71 tests pass, 13 new in `test/service/ble_commands_test.dart`
- [ ] Extended commands against a real scooter, especially the notify-lifetime change
- [ ] Widget state after backgrounding, to confirm the duplicate-service fix did not break the push path

### Notes

No hardware testing. Everything above is static analysis plus unit tests over
fakes.

Removing the notify-off toggle opens a narrow window where a straggler reply to
a timed-out command could be consumed as the next command's response. It is
microseconds wide against the whole-command window that existed before, and
`_withExtendedChannel` already serialises callers. Closing it properly needs
response tagging, which the protocol does not carry.

`readExtendedList` waits for `count` successfully parsed entries and skips
rejected ones without decrementing, so one malformed entry still runs to
timeout. Pre-existing, left for a follow-up.

Conflicts with #156, which also edits `ble_commands.dart`.
