### PR TITLE
Forget the scooter's half of the bond too

### DIFF
--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -716,6 +716,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
           identity.supportsHibernateFor = false;
           identity.supportsScheduledHibernation = false;
           identity.supportsApnConfig = false;
+          identity.supportsBondForget = false;
         }
         notifyListeners();
       },
@@ -778,6 +779,22 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
     if (probedScooterId != null && savedScooters.containsKey(probedScooterId)) {
       savedScooters[probedScooterId]!.supportsApnConfig = supportsApnConfig;
     }
+    notifyListeners();
+
+    bool? supportsBondForget;
+    try {
+      final caps = await commands.getLsCapabilitiesCommand(myScooter, characteristicRepository, "ble");
+      supportsBondForget = caps.contains("forget");
+    } catch (e, stack) {
+      log.warning("ble capability probe failed", e, stack);
+      supportsBondForget = false;
+    }
+    if (generation != _lsProbeGeneration) return;
+    // Not cached on the SavedScooter, unlike the two above. Nothing renders it,
+    // so there is no flicker to avoid, and the answer depends on the nRF
+    // firmware rather than the app: a cache would go stale the moment the
+    // scooter takes a firmware update.
+    identity.supportsBondForget = supportsBondForget;
     notifyListeners();
   }
 
@@ -1049,10 +1066,65 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
     return store.getIds(onlyAutoConnect: onlyAutoConnect);
   }
 
+  /// Asks the connected scooter to forget this phone, so forgetting clears both
+  /// halves of the bond rather than leaving the scooter holding a peer entry
+  /// for a phone that no longer knows it. Those entries accumulate against a
+  /// whitelist with far fewer slots than the peer store has room for.
+  ///
+  /// Best effort, and deliberately so: a scooter running older firmware, or one
+  /// that never answers, still gets forgotten locally. The user asked for that,
+  /// and the alternative is a scooter the app can neither use nor get rid of.
+  ///
+  /// Returns whether the scooter agreed.
+  Future<bool> _clearScooterSideBond() async {
+    if (myScooter == null || identity.isLibrescoot != true) return false;
+    // Only skip on a probe that came back negative. A probe still in flight, or
+    // one that failed, is not a reason to leave the bond behind: the command
+    // answers for itself, and the cost of asking is one error reply.
+    if (identity.supportsBondForget == false) {
+      log.info("Scooter cannot clear its own bond, forgetting the phone side only");
+      return false;
+    }
+    final scooter = myScooter!;
+    try {
+      await commands.forgetBondCommand(scooter, characteristicRepository);
+    } catch (e, stack) {
+      log.warning("Scooter did not clear its bond, forgetting the phone side only", e, stack);
+      return false;
+    }
+
+    // The scooter acknowledges first and then drops the link to carry the
+    // delete out, because its peer manager cannot delete a peer that is still
+    // connected. So the disconnect is the confirmation, and tearing the link
+    // down from this side before it happens is not merely early: the firmware
+    // resolves the peer from the live connection, finds nothing connected, and
+    // leaves the bond exactly where it was.
+    try {
+      await scooter.connectionState
+          .firstWhere((state) => state == BluetoothConnectionState.disconnected)
+          .timeout(const Duration(seconds: 5));
+      log.info("Scooter forgot this phone and dropped the link");
+      return true;
+    } on TimeoutException {
+      log.warning("Scooter acknowledged the forget but never dropped the link; its bond may remain");
+      return false;
+    }
+  }
+
   Future<void> forgetSavedScooter(String id) async {
     if (myScooter?.remoteId.toString() == id) {
       // this is the currently connected scooter
+      //
+      // stopAutoRestart first: clearing the scooter's bond makes it drop the
+      // link, and an auto-restart racing that would reconnect to a scooter we
+      // are in the middle of forgetting.
       stopAutoRestart();
+      // Before removeBond(), not after. The command only travels over the
+      // authenticated link, so once the phone drops its bond there is nothing
+      // left to send it over. This returns with the link already down when the
+      // scooter agreed; the disconnect below is then a no-op that also covers
+      // the scooters that did not.
+      await _clearScooterSideBond();
       await myScooter?.disconnect();
       myScooter?.removeBond();
       myScooter = null;

--- a/lib/service/ble_commands.dart
+++ b/lib/service/ble_commands.dart
@@ -767,6 +767,19 @@ Future<void> hibernateCancelCommand(
   }
 }
 
+/// Pulls the command name out of one `cap:<category>:<command>[ <args>]` entry.
+///
+/// The count header is consumed by [readExtendedList] before this sees
+/// anything, so every message reaching here should be an entry. Returns null
+/// for one that isn't for [category], which [readExtendedList] then skips.
+@visibleForTesting
+String? parseCapabilityEntry(String category, String msg) {
+  final prefix = "cap:$category:";
+  if (!msg.startsWith(prefix)) return null;
+  final name = msg.substring(prefix.length).split(" ").first;
+  return name.isNotEmpty ? name : null;
+}
+
 /// Queries the scooter's power-management capabilities (e.g. "hibernate-for",
 /// "hibernate-cancel").
 Future<Set<String>> getPmCapabilitiesCommand(
@@ -798,13 +811,7 @@ Future<Set<String>> getLsCapabilitiesCommand(
   try {
     await sendCommand(scooter, repo, "cap:$category", characteristic: cmd);
     final stream = listener.responses.timeout(const Duration(seconds: 10));
-    // format: cap:<category>:count:<n>, then cap:<category>:<command>[ <args>].
-    final prefix = "cap:$category:";
-    final entries = await readExtendedList(stream, (msg) {
-      if (!msg.startsWith(prefix)) return null;
-      final name = msg.substring(prefix.length).split(" ").first;
-      return name.isNotEmpty ? name : null;
-    });
+    final entries = await readExtendedList(stream, (msg) => parseCapabilityEntry(category, msg));
     return entries.toSet();
   } on TimeoutException {
     log.info("getLsCapabilitiesCommand: timeout, assuming no $category capabilities");
@@ -818,6 +825,32 @@ Future<Set<String>> getLsCapabilitiesCommand(
     await listener.cancel();
   }
 });
+
+/// Asks the scooter to forget this phone, clearing the scooter's half of the
+/// bond. Only the caller's own bond can be dropped this way: the scooter
+/// resolves the peer from the live connection, so there is nothing to pass and
+/// no way to reach anyone else's bond.
+///
+/// Send this while still connected and before dropping the phone's own bond.
+/// The command only travels over the authenticated link, and the scooter
+/// disconnects to carry the delete out, so there is no second chance.
+///
+/// The reply means the command was accepted, not that the bond is gone: nothing
+/// on the vehicle exposes a peer list. The scooter dropping the link afterwards
+/// is the observable part, so callers should wait for it.
+///
+/// Throws if the scooter refuses or never answers. Needs librescoot 1.3 with
+/// nRF firmware v2.8.0-ls or later; probe `cap:ble` for "forget" first.
+Future<void> forgetBondCommand(
+  BluetoothDevice? scooter,
+  CharacteristicRepository repo,
+) async {
+  final response = await sendLsExtendedCommand(scooter, repo, "ble:forget");
+  if (response != "ble:forget:ok") {
+    log.warning("Scooter would not forget this phone, response: $response");
+    throw "Failed to forget the scooter side of the bond, response: $response";
+  }
+}
 
 /// Reads a librescoot settings key via the generic get command. Returns null
 /// if the key or the get command itself is unsupported (or on timeout), and

--- a/lib/state/scooter_identity.dart
+++ b/lib/state/scooter_identity.dart
@@ -21,11 +21,13 @@ class ScooterIdentity {
   bool? supportsHibernateFor;
   bool? supportsScheduledHibernation;
   bool? supportsApnConfig;
+  bool? supportsBondForget;
 
   void resetLsCapabilities() {
     supportsHibernateFor = null;
     supportsScheduledHibernation = null;
     supportsApnConfig = null;
+    supportsBondForget = null;
   }
 
   void wireNrfVersion(

--- a/test/service/ble_commands_test.dart
+++ b/test/service/ble_commands_test.dart
@@ -88,6 +88,30 @@ void main() {
     });
   });
 
+  group('parseCapabilityEntry', () {
+    test('pulls the command name out of an entry', () {
+      expect(parseCapabilityEntry('pm', 'cap:pm:hibernate-cancel'), 'hibernate-cancel');
+      expect(parseCapabilityEntry('ble', 'cap:ble:forget'), 'forget');
+    });
+
+    test('drops the argument placeholder', () {
+      expect(parseCapabilityEntry('pm', 'cap:pm:hibernate-for <duration>'), 'hibernate-for');
+    });
+
+    test('keeps colons inside a command name', () {
+      expect(parseCapabilityEntry('nav', 'cap:nav:fav:add'), 'fav:add');
+    });
+
+    test('ignores entries for another category', () {
+      expect(parseCapabilityEntry('ble', 'cap:pm:hibernate-cancel'), isNull);
+      expect(parseCapabilityEntry('ble', 'ble:forget:ok'), isNull);
+    });
+
+    test('ignores an entry with nothing after the prefix', () {
+      expect(parseCapabilityEntry('ble', 'cap:ble:'), isNull);
+    });
+  });
+
   group('ExtendedResponseListener', () {
     test('delivers responses emitted before the caller starts reading', () async {
       final source = StreamController<List<int>>.broadcast();


### PR DESCRIPTION
Forgetting a scooter cleared only the phone's half. The scooter kept its peer entry, so it went on answering a phone that had forgotten it, and those entries pile up against a radio whitelist with far fewer slots than the peer store has room for. That matters in every vehicle state except parked, all of which advertise whitelist-only.

The scooter side now exists: `ble:forget` on the extended channel, from librescoot 1.3 with nRF firmware v2.8.0-ls or later (librescoot/bluetooth-service 7e54464). Probed with `cap:ble` alongside the other capabilities.

## Two orderings carry this

**The command goes out before `removeBond()`.** It only travels over the authenticated link, so once the phone drops its bond there is nothing left to send it over.

**The app waits for the scooter to drop the link rather than disconnecting itself.** The firmware resolves the peer from the live connection, so a phone-initiated disconnect landing first leaves it with nothing connected and the bond exactly where it was. This was wrong in an earlier draft, and it is the kind of wrong that reports success.

It is also the only confirmation available. Nothing on the vehicle exposes a peer list, `lsc bluetooth status` does not print one, and bluetooth-service does not forward nRF logs, so `ble:forget:ok` means the command was accepted and not that the bond is gone.

## Failure is quiet and local

Old firmware, a refusal or a timeout still forgets the phone side, because that is what the user asked for and the alternative is a scooter the app can neither use nor get rid of. Nothing claims both halves were cleared, so there are no new strings to translate.

## Also

`parseCapabilityEntry` is lifted out of `getLsCapabilitiesCommand` so the parse can be tested directly. Behaviour unchanged. `supportsBondForget` is deliberately not cached on `SavedScooter` the way `supportsHibernateFor` and `supportsApnConfig` are: nothing renders it so there is no flicker to avoid, and the answer depends on the nRF firmware, which a cache would go stale against on the next update.

## Testing

93 tests pass, `flutter analyze` clean. On a bench MDB on v2.8.0-ls with a Pixel 8: `cap:ble` lists `forget`, `ble:forget` is acknowledged, and the delete-bond reaches the nRF after the ack rather than before it.

That the bond is actually gone is **not yet proven**. A passkey on the next pair does not show it, since the phone had dropped its own keys and would be asked either way. The test that does is whether the scooter still advertises in a whitelist-only state once its last bond is deleted, and it is being run now. Worth holding the merge for that result.

One behaviour to be aware of either way: if the deleted bond was the scooter's last one and the vehicle is not parked, the rebuilt whitelist is empty and the scooter stops advertising entirely until it is parked again. Documented in unu-tech-reference rather than changed, since a scooter with no bonds has always behaved that way and re-pairing needs the dashboard awake for the passkey regardless.

Closes the last open item of the BLE flow review (#10, forget only clears the phone side).