### PR TITLE
Bond on any Android connect, and fix a null deref on disconnect

### DIFF
--- a/lib/onboarding_screen.dart
+++ b/lib/onboarding_screen.dart
@@ -393,7 +393,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> with TickerProvider
       // Awaited on purpose. Firing this off and moving to step 4 anyway left
       // the screen on "Connecting..." forever whenever the attempt failed,
       // because the rejected future never reached the catch below.
-      await service.connectToScooterId(candidate.id, initialConnect: true);
+      await service.connectToScooterId(candidate.id);
     } catch (e, stack) {
       log.severe("Error connecting to scooter!", e, stack);
       if (!mounted) return;

--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -379,10 +379,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
 
   StreamSubscription<BluetoothConnectionState>? _connectionStateSubscription;
 
-  Future<void> connectToScooterId(
-    String id, {
-    bool initialConnect = false,
-  }) async {
+  Future<void> connectToScooterId(String id) async {
     log.info("Connecting to scooter with ID: $id");
     _foundSth = true;
     state = ScooterState.linking;
@@ -392,10 +389,14 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       // wait for the connection to be established
       log.info("Connecting to ${attemptedScooter.remoteId}");
       await attemptedScooter.connect(timeout: const Duration(seconds: 30));
-      if (initialConnect && Platform.isAndroid) {
-        // Adding a scooter the phone is already paired with is a normal thing
-        // to do (app reinstalled, data cleared), and asking to bond again just
-        // costs a round trip.
+      if (Platform.isAndroid) {
+        // Bond on any connect, not just when adding a scooter. Until nRF
+        // v2.8.0-ls-2 the scooter sent an SMP Security Request on every
+        // connection and Android started bonding off the back of it, so this
+        // only had to cover the first pairing. That request is gone now, so a
+        // saved scooter whose bond went missing (forgotten in Android's
+        // settings, app data restored onto another phone) would connect and
+        // then fail its first encrypted read instead.
         final BluetoothBondState bondState = await attemptedScooter.bondState.first;
         if (bondState == BluetoothBondState.bonded) {
           log.info("Already bonded with ${attemptedScooter.remoteId}, no pairing request needed");

--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -461,13 +461,17 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       // listen for disconnects, replacing the previous connection's listener
       // rather than piling another one on top of it
       await _connectionStateSubscription?.cancel();
+      // Captured, not read back off myScooter: this listener belongs to one
+      // scooter, and myScooter is null by the time the disconnect arrives when
+      // the link drops during a forget or a rolled-back connect.
+      final String listeningTo = myScooter!.remoteId.toString();
       _connectionStateSubscription = myScooter!.connectionState.listen((BluetoothConnectionState state) async {
         if (state == BluetoothConnectionState.disconnected) {
           connected = false;
           this.state = ScooterState.disconnected;
           log.info("Lost connection to scooter! :(");
           // update the ping again
-          updateScooterPing(myScooter!.remoteId.toString());
+          updateScooterPing(listeningTo);
           // Restart the process if we're not already doing so
           // start(); // this leads to some conflicts right now if the phone auto-connects, so we're not doing it
         }


### PR DESCRIPTION
Two Android bonding fixes found while testing against a bench scooter.

### Bond on any connect

The bonding block was gated on `initialConnect`, which only onboarding passes,
so every reconnect skipped it. That was fine while the scooter sent an SMP
Security Request on connect, because Android began bonding off the back of it
whether or not the app asked. nRF v2.8.0-ls-2 removed that request, to stop
Android raising two pairing dialogs for a single bond, and nothing was left
driving the bond on a reconnect.

A saved scooter whose bond has gone missing then connects and fails its first
encrypted read. Android does recover, retrying with `AUTHENTICATION_MITM`, but
the failure is visible first: five consecutive search-or-connect errors over
about 19 seconds on the bench.

The already-bonded early-out is unchanged, so the usual path costs one cached
`bondState` read and raises no prompt. `initialConnect` had no other readers and
goes with it.

### Null dereference in the disconnect listener

`updateScooterPing` read `myScooter!` from inside the connection-state listener.
`myScooter` is already null when the link drops during a forget or a rolled-back
connect, so the disconnect threw `Null check operator used on a null value` and
the ping update was skipped. Flutter catches it at the zone boundary, so it
surfaced as a logged unhandled exception rather than a crash. The listener
belongs to one scooter, so it now captures that id when it is wired.

Pre-existing, unrelated to the first change, and included here because it lives
in the same connect path.

### Test plan

- [x] `flutter analyze` clean, 93 tests pass
- [x] 11 bonded reconnect cycles, Pixel 8 on Android 17 against a scooter on nRF v2.8.0-ls-4: zero pairing prompts, so the already-bonded path raises no dialog
- [x] Recovery from a scooter-side bond wipe: the app now prompts to pair instead of retrying silently
- [x] Null dereference no longer thrown on a disconnect that races a forget
- [ ] iOS, which takes neither path (`Platform.isAndroid`) and should be unaffected

### Notes

The reconnect cycles doubled as a latency measurement: connect to first
successful encrypted read was min 0.896 s, median 1.011 s, max 1.802 s over 11
cycles, with no failures or retries. Service discovery is inside that window.

A scooter that has been reflashed or factory reset leaves the phone holding a
bond the scooter no longer has. On this branch that recovers: Android drops its
own stale bond after the repeated encryption failures, and the widened path then
initiates pairing. The user still sees a failure window and an unexplained
pairing prompt, so whether to handle that case explicitly is worth deciding
separately.

An explicit recovery that cleared our half of the bond on a post-link connect
failure was written and dropped before this PR. It never fired in testing,
because Android clears the bond first, and untested code that can call
`removeBond()` is not worth carrying for a case the simpler change already
covers.
