### PR TITLE
Surface wake-and-unlock failures

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -43,6 +43,7 @@
     "home_seat_button_closed": "Sitz öffnen",
     "home_seat_button_open": "Sitz ist offen",
     "home_unlock_button": "Halten zum Starten",
+    "home_unlock_failed": "Der Roller konnte nicht aufgeweckt und entriegelt werden. Bitte versuche es erneut.",
     "home_lock_button": "Halten für Standby",
     "home_controls_button": "Steuerung",
     "home_reconnect_button": "Suchen",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -43,6 +43,7 @@
     "home_seat_button_closed": "Open seat",
     "home_seat_button_open": "Seat is open!",
     "home_unlock_button": "Hold to start",
+    "home_unlock_failed": "Couldn't wake and unlock the scooter. Try again.",
     "home_lock_button": "Hold for standby",
     "home_controls_button": "Controls",
     "home_reconnect_button": "Reconnect",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -43,6 +43,7 @@
     "home_seat_button_closed": "Ouvrir le coffre",
     "home_seat_button_open": "Coffre ouvert",
     "home_unlock_button": "Maintenir pour démarrer",
+    "home_unlock_failed": "Impossible de réveiller et déverrouiller le scooter. Réessayez.",
     "home_lock_button": "Maintenir pour veille",
     "home_controls_button": "Commandes",
     "home_reconnect_button": "Reconnecter",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -43,6 +43,7 @@
     "home_seat_button_closed": "Buddy openen",
     "home_seat_button_open": "Buddy is open",
     "home_unlock_button": "Vasthouden om te starten",
+    "home_unlock_failed": "De scooter kon niet worden gewekt en ontgrendeld. Probeer opnieuw.",
     "home_lock_button": "Vasthouden voor standby",
     "home_controls_button": "Bediening",
     "home_reconnect_button": "Opnieuw verbinden",

--- a/assets/i18n/pi.json
+++ b/assets/i18n/pi.json
@@ -43,6 +43,7 @@
     "home_seat_button_closed": "Open chest",
     "home_seat_button_open": "Chest open",
     "home_unlock_button": "Set sail",
+    "home_unlock_failed": "Couldn't wake and unlock the scooter. Try again.",
     "home_lock_button": "Drop anchor",
     "home_controls_button": "The helm",
     "home_reconnect_button": "Reconnect",

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -420,9 +420,13 @@ class _HomeScreenState extends State<HomeScreen> {
                                                     }
                                                   }
                                                   try {
-                                                    if (!context.mounted) return;
+                                                    if (!context.mounted) {
+                                                      return;
+                                                    }
                                                     await context.read<ScooterService>().lock();
-                                                    if (!context.mounted) return;
+                                                    if (!context.mounted) {
+                                                      return;
+                                                    }
                                                     if (context.read<ScooterService>().hazardLocking) {
                                                       _flashHazards(1);
                                                     }
@@ -459,14 +463,27 @@ class _HomeScreenState extends State<HomeScreen> {
                                                         showHandlebarWarning(
                                                           didNotUnlock: true,
                                                         );
+                                                      } catch (e, stack) {
+                                                        log.warning("Could not unlock scooter", e, stack);
+                                                        if (context.mounted) {
+                                                          Fluttertoast.showToast(
+                                                            msg: FlutterI18n.translate(context, "home_unlock_failed"),
+                                                          );
+                                                        }
                                                       }
                                                     }
-                                                  : (state == ScooterState.standby
-                                                      ? () {
-                                                          context.read<ScooterService>().unlock();
-                                                          // TODO: Flash hazards in visual
+                                                  : () async {
+                                                      try {
+                                                        await context.read<ScooterService>().wakeUpAndUnlock();
+                                                      } catch (e, stack) {
+                                                        log.warning("Could not wake and unlock scooter", e, stack);
+                                                        if (context.mounted) {
+                                                          Fluttertoast.showToast(
+                                                            msg: FlutterI18n.translate(context, "home_unlock_failed"),
+                                                          );
                                                         }
-                                                      : context.read<ScooterService>().wakeUpAndUnlock)))
+                                                      }
+                                                    }))
                                           : null,
                                       icon: state != null && state.isOn ? Icons.lock_open : Icons.lock_outline,
                                       label: state != null && state.isOn

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -475,6 +475,9 @@ class _HomeScreenState extends State<HomeScreen> {
                                                   : () async {
                                                       try {
                                                         await context.read<ScooterService>().wakeUpAndUnlock();
+                                                        if (context.mounted && context.read<ScooterService>().hazardLocking) {
+                                                          _flashHazards(2);
+                                                        }
                                                       } catch (e, stack) {
                                                         log.warning("Could not wake and unlock scooter", e, stack);
                                                         if (context.mounted) {

--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -839,6 +839,8 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       source: source,
     );
 
+    log.info('[wake-timing] unlock command acknowledged');
+
     if (settings.openSeatOnUnlock) {
       await Future.delayed(const Duration(seconds: 1), () {
         openSeat(source: EventSource.auto);
@@ -863,6 +865,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
 
   Future<void> wakeUpAndUnlock({EventSource? source}) async {
     final stopwatch = Stopwatch()..start();
+    log.info('[wake-timing] wake-and-unlock started');
     final waiter = StateWaiter<ScooterState?>(
       notifier: this,
       value: () => state,
@@ -874,12 +877,17 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
 
     try {
       await Future.wait([wakeUp(), standby], eagerError: true);
+      log.info('[wake-timing] standby reached after ${stopwatch.elapsed.inMilliseconds} ms');
 
       final remaining = wakeAndUnlockTimeout - stopwatch.elapsed;
       if (remaining <= Duration.zero) {
         throw TimeoutException('Timed out waking and unlocking the scooter.', wakeAndUnlockTimeout);
       }
       await unlock(source: source ?? EventSource.app).timeout(remaining);
+      log.info('[wake-timing] wake-and-unlock completed after ${stopwatch.elapsed.inMilliseconds} ms');
+    } catch (e, stack) {
+      log.warning('[wake-timing] wake-and-unlock failed after ${stopwatch.elapsed.inMilliseconds} ms: $e', e, stack);
+      rethrow;
     } finally {
       waiter.cancel();
     }
@@ -955,6 +963,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
 
   Future<void> wakeUp() async {
     await commands.wakeUpCommand(myScooter, characteristicRepository);
+    log.info('[wake-timing] wake command acknowledged');
   }
 
   Future<void> hibernate() async {

--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -28,13 +28,14 @@ import '../state/battery_state.dart';
 import '../state/scooter_identity.dart';
 import '../state/vehicle_status.dart';
 import '../service/scooter_storage.dart';
+import '../service/state_waiter.dart';
 import '../service/ble_commands.dart' as commands;
 import '../service/ble_scanner.dart';
 import '../service/user_settings.dart';
 
-const bootingTimeSeconds = 25;
 const keylessCooldownSeconds = 60;
 const handlebarCheckSeconds = 5;
+const wakeAndUnlockTimeout = Duration(seconds: 45);
 
 class ScooterService with ChangeNotifier, WidgetsBindingObserver {
   final log = Logger('ScooterService');
@@ -861,15 +862,26 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
   }
 
   Future<void> wakeUpAndUnlock({EventSource? source}) async {
-    wakeUp();
-
-    await _waitForScooterState(
-      ScooterState.standby,
-      const Duration(seconds: bootingTimeSeconds + 5),
+    final stopwatch = Stopwatch()..start();
+    final waiter = StateWaiter<ScooterState?>(
+      notifier: this,
+      value: () => state,
+      expected: ScooterState.standby,
+      timeout: wakeAndUnlockTimeout,
+      isDisconnected: (state) => state == ScooterState.disconnected,
     );
+    final standby = waiter.wait();
 
-    if (_state == ScooterState.standby) {
-      unlock();
+    try {
+      await Future.wait([wakeUp(), standby], eagerError: true);
+
+      final remaining = wakeAndUnlockTimeout - stopwatch.elapsed;
+      if (remaining <= Duration.zero) {
+        throw TimeoutException('Timed out waking and unlocking the scooter.', wakeAndUnlockTimeout);
+      }
+      await unlock(source: source ?? EventSource.app).timeout(remaining);
+    } finally {
+      waiter.cancel();
     }
   }
 
@@ -1002,35 +1014,6 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       }
     }
     return false;
-  }
-
-  Future<void> _waitForScooterState(
-    ScooterState expectedScooterState,
-    Duration limit,
-  ) async {
-    Completer<void> completer = Completer<void>();
-
-    // Check new state every 2s
-    var timer = Timer.periodic(const Duration(seconds: 2), (timer) {
-      ScooterState? scooterState = _state;
-      log.info("Waiting for $expectedScooterState, and got: $scooterState...");
-      if (scooterState == expectedScooterState) {
-        log.info("Found $expectedScooterState, cancel timer...");
-        timer.cancel();
-        completer.complete();
-      }
-    });
-
-    // Clean up
-    Future.delayed(limit, () {
-      log.info("Timer limit reached after $limit");
-      timer.cancel();
-      if (!completer.isCompleted) {
-        completer.complete();
-      }
-    });
-
-    return completer.future;
   }
 
   // SAVED SCOOTER MANAGEMENT

--- a/lib/service/state_waiter.dart
+++ b/lib/service/state_waiter.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Waits for a value supplied by a [ChangeNotifier] without polling.
+class StateWaiter<T> {
+  StateWaiter({
+    required ChangeNotifier notifier,
+    required T Function() value,
+    required this.expected,
+    required this.timeout,
+    required this.isDisconnected,
+  }) : _notifier = notifier,
+       _value = value;
+
+  final ChangeNotifier _notifier;
+  final T Function() _value;
+  final T expected;
+  final Duration timeout;
+  final bool Function(T value) isDisconnected;
+  void Function()? _cancel;
+
+  Future<void> wait() {
+    late final VoidCallback listener;
+    Timer? timer;
+    final completer = Completer<void>();
+
+    void finish([Object? error, StackTrace? stackTrace]) {
+      _cancel?.call();
+      _cancel = null;
+      if (completer.isCompleted) return;
+      if (error == null) {
+        completer.complete();
+      } else {
+        completer.completeError(error, stackTrace);
+      }
+    }
+
+    listener = () {
+      final current = _value();
+      if (current == expected) {
+        finish();
+      } else if (isDisconnected(current)) {
+        finish(StateError('Scooter disconnected while waiting for $expected.'));
+      }
+    };
+
+    _notifier.addListener(listener);
+    _cancel = () {
+      timer?.cancel();
+      _notifier.removeListener(listener);
+    };
+    timer = Timer(timeout, () {
+      finish(TimeoutException('Timed out waiting for $expected.', timeout));
+    });
+    return completer.future;
+  }
+
+  void cancel() {
+    _cancel?.call();
+    _cancel = null;
+  }
+}

--- a/test/service/state_waiter_test.dart
+++ b/test/service/state_waiter_test.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:unustasis/service/state_waiter.dart';
+
+class _Notifier extends ChangeNotifier {
+  String state = 'booting';
+  int removals = 0;
+
+  void update(String value) {
+    state = value;
+    notifyListeners();
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    removals++;
+    super.removeListener(listener);
+  }
+}
+
+StateWaiter<String> _waiter(
+  _Notifier notifier, {
+  Duration timeout = const Duration(seconds: 1),
+}) {
+  return StateWaiter<String>(
+    notifier: notifier,
+    value: () => notifier.state,
+    expected: 'standby',
+    timeout: timeout,
+    isDisconnected: (state) => state == 'disconnected',
+  );
+}
+
+void main() {
+  test('completes when a state notification reports standby', () async {
+    final notifier = _Notifier();
+    final future = _waiter(notifier).wait();
+
+    notifier.update('standby');
+
+    await expectLater(future, completes);
+    expect(notifier.removals, 1);
+  });
+
+  test('reports a timeout and removes its listener', () async {
+    final notifier = _Notifier();
+    final future = _waiter(
+      notifier,
+      timeout: const Duration(milliseconds: 1),
+    ).wait();
+
+    await expectLater(future, throwsA(isA<TimeoutException>()));
+    expect(notifier.removals, 1);
+  });
+
+  test('reports disconnect notifications and removes its listener', () async {
+    final notifier = _Notifier();
+    final future = _waiter(notifier).wait();
+
+    notifier.update('disconnected');
+
+    await expectLater(future, throwsA(isA<StateError>()));
+    expect(notifier.removals, 1);
+  });
+}


### PR DESCRIPTION
Fixes #28

## Summary
- wait up to 45 seconds for the scooter to reach standby after waking
- use state notifications rather than polling
- surface wake, disconnect, timeout, and unlock failures to the user

## Validation
- flutter analyze
- flutter test test/service/state_waiter_test.dart