### PR TITLE
Verify OTA downloads and fail same-version installs early

### DIFF
--- a/lib/domain/ota_protocol.dart
+++ b/lib/domain/ota_protocol.dart
@@ -31,6 +31,7 @@ class OtaProtocol {
   static const int startBusy = 0x11;
   static const int startBadParams = 0x12;
   static const int startInstalling = 0x13;
+  static const int startAlreadyInstalled = 0x14;
 
   // ACK flags.
   static const int ackFlagRewind = 0x01;

--- a/lib/domain/update_planner.dart
+++ b/lib/domain/update_planner.dart
@@ -16,7 +16,19 @@ class FirmwareAsset {
   final String url;
   final int size;
 
-  const FirmwareAsset({required this.name, required this.url, required this.size});
+  /// Hex SHA-256 from the channel JSON, "" on older channels without
+  /// checksums. Verified against the downloaded bundle before transfer: the
+  /// START SHA is computed from the same file, so without this check a
+  /// corrupted download transfers cleanly and only fails as an opaque
+  /// install error after a full BLE transfer.
+  final String sha256;
+
+  const FirmwareAsset({
+    required this.name,
+    required this.url,
+    required this.size,
+    this.sha256 = "",
+  });
 
   bool get isDelta => name.endsWith(".delta");
   bool get isMender => name.endsWith(".mender");
@@ -25,7 +37,12 @@ class FirmwareAsset {
     final name = json["name"] as String? ?? "";
     final url = json["url"] as String? ?? "";
     if (name.isEmpty || url.isEmpty) return null;
-    return FirmwareAsset(name: name, url: url, size: (json["size"] as num?)?.toInt() ?? 0);
+    return FirmwareAsset(
+      name: name,
+      url: url,
+      size: (json["size"] as num?)?.toInt() ?? 0,
+      sha256: json["sha256"] as String? ?? "",
+    );
   }
 }
 

--- a/lib/ls_ota_screen.dart
+++ b/lib/ls_ota_screen.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:crypto/crypto.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
@@ -308,6 +309,7 @@ class _LsOtaScreenState extends State<LsOtaScreen> {
     final dir = await getApplicationSupportDirectory();
     final file = File("${dir.path}/ota/${asset.name}");
     if (await file.exists() && await file.length() == asset.size) {
+      await _verifyBundle(file, asset);
       return file; // already downloaded
     }
     await file.parent.create(recursive: true);
@@ -344,10 +346,39 @@ class _LsOtaScreenState extends State<LsOtaScreen> {
       } finally {
         await sink.close();
       }
+      await _verifyBundle(file, asset);
       return file;
     } finally {
       if (mounted) setState(() => _downloading = false);
     }
+  }
+
+  /// Verifies the bundle against the channel index checksum when the index
+  /// provides one. The SHA sent in OTA START is computed from this same file,
+  /// so a corrupted download would otherwise transfer cleanly (self-consistent
+  /// hash) and only surface as an opaque install failure after a full BLE
+  /// transfer. Deletes the file on mismatch so the retry re-downloads.
+  Future<void> _verifyBundle(File file, FirmwareAsset asset) async {
+    if (asset.sha256.isEmpty) return;
+    log.info("Verifying ${asset.name} against channel checksum");
+    final digest = await _sha256Hex(file);
+    if (digest == asset.sha256.toLowerCase()) return;
+    try {
+      await file.delete();
+    } catch (e) {
+      log.warning("Deleting corrupt bundle failed: $e");
+    }
+    throw "Downloaded bundle is corrupt (checksum mismatch), please retry";
+  }
+
+  Future<String> _sha256Hex(File f) async {
+    final output = _DigestSink();
+    final input = sha256.startChunkedConversion(output);
+    await for (final chunk in f.openRead()) {
+      input.add(chunk);
+    }
+    input.close();
+    return output.events.single.toString();
   }
 
   String _formatBytes(num bytes) {
@@ -721,4 +752,16 @@ class _LsOtaScreenState extends State<LsOtaScreen> {
       ),
     );
   }
+}
+
+/// Minimal accumulator sink for chunked hashing (mirrors the pattern in
+/// ota_transfer_service.dart; kept local to avoid a cross-file dependency).
+class _DigestSink implements Sink<Digest> {
+  final events = <Digest>[];
+
+  @override
+  void add(Digest event) => events.add(event);
+
+  @override
+  void close() {}
 }

--- a/lib/service/ota_transfer_service.dart
+++ b/lib/service/ota_transfer_service.dart
@@ -196,10 +196,16 @@ class OtaTransferService extends ChangeNotifier {
         bundleId: bundleId,
       );
 
+      // ATT-MTU minus 3 (ATT header) minus 4 (DATA offset prefix). No floor:
+      // a chunk larger than the negotiated MTU is truncated/rejected on every
+      // write, which surfaces as endless rewinds instead of a clean error.
       final chunkSize = min(
         ack.maxChunk,
-        min(OtaProtocol.maxChunkSize, max(20, scooter.mtuNow - 3 - 4)),
+        min(OtaProtocol.maxChunkSize, scooter.mtuNow - 7),
       );
+      if (chunkSize < 1) {
+        throw "Negotiated ATT MTU (${scooter.mtuNow}) too small for OTA";
+      }
       final window = max(1, ack.windowChunks) * chunkSize;
 
       raf = await bundle.open();
@@ -301,6 +307,8 @@ class OtaTransferService extends ChangeNotifier {
               throw "An installation is already in progress";
             case OtaProtocol.startBusy:
               throw "Another transfer is in progress";
+            case OtaProtocol.startAlreadyInstalled:
+              throw "This version is already installed on the scooter";
             default:
               throw "Scooter rejected the transfer (code ${ack.status})";
           }


### PR DESCRIPTION
## Summary
- verify downloaded bundles against the `sha256` in the release index, on fresh downloads and on the cached-file path; a mismatch deletes the file and asks for a retry
- drop the `max(20, ...)` chunk-size floor, which sent oversized writes when the ATT MTU stayed at 23 and showed up as endless rewinds; a too-small MTU now fails at the handshake
- handle START_ACK `0x14` (version already installed on that board) with a readable message; bluetooth-service main sends it, older scooters never do

No nRF firmware change involved, the tunnel relays the status byte as-is.

## Validation
- dart analyze
- flutter test test/domain/ota_protocol_test.dart test/domain/update_planner_test.dart