### PR TITLE
Show the active navigation destination

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -461,6 +461,7 @@
     "nav_destination_fallback": "Ziel",
     "nav_rename": "Umbenennen",
     "nav_status_active_title": "Navigation aktiv",
+    "nav_stop_button": "Beenden",
     "nav_status_pending_title": "Navigation ausstehend",
     "nav_status_active_subtitle": "Folge den Anweisungen auf dem Display deines Rollers.",
     "nav_status_pending_subtitle": "Dein Roller navigiert zu {destination}, sobald du dich verbindest.",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -461,6 +461,7 @@
     "nav_destination_fallback": "Destination",
     "nav_rename": "Rename",
     "nav_status_active_title": "Navigation is active",
+    "nav_stop_button": "Stop",
     "nav_status_pending_title": "Pending navigation",
     "nav_status_active_subtitle": "Follow directions on your scooter's display.",
     "nav_status_pending_subtitle": "Your scooter will navigate to {destination} next time you connect.",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -461,6 +461,7 @@
     "nav_destination_fallback": "Destination",
     "nav_rename": "Renommer",
     "nav_status_active_title": "Navigation active",
+    "nav_stop_button": "Arrêter",
     "nav_status_pending_title": "Navigation en attente",
     "nav_status_active_subtitle": "Suivez les indications sur l'écran de votre scooter.",
     "nav_status_pending_subtitle": "Votre scooter naviguera vers {destination} à la prochaine connexion.",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -461,6 +461,7 @@
     "nav_destination_fallback": "Bestemming",
     "nav_rename": "Hernoemen",
     "nav_status_active_title": "Navigatie actief",
+    "nav_stop_button": "Stoppen",
     "nav_status_pending_title": "Navigatie in de wacht",
     "nav_status_active_subtitle": "Volg de aanwijzingen op het scherm van je scooter.",
     "nav_status_pending_subtitle": "Je scooter navigeert naar {destination} de volgende keer dat je verbinding maakt.",

--- a/assets/i18n/pi.json
+++ b/assets/i18n/pi.json
@@ -441,6 +441,7 @@
     "nav_destination_fallback": "Destination",
     "nav_rename": "Rename",
     "nav_status_active_title": "Navigation is active, arr!",
+    "nav_stop_button": "Belay",
     "nav_status_pending_title": "Navigation be pending",
     "nav_status_active_subtitle": "Follow the charts on yer scooter's display.",
     "nav_status_pending_subtitle": "Yer scooter will sail to {destination} next time ye connect.",

--- a/lib/navigation_screen.dart
+++ b/lib/navigation_screen.dart
@@ -214,6 +214,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
         service.characteristicRepository,
         destination.id!,
       );
+      service.setActiveNavigation(destination);
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -283,6 +284,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
         service.characteristicRepository,
         dest,
       );
+      service.setActiveNavigation(dest);
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -556,9 +558,10 @@ class _NavigationScreenState extends State<NavigationScreen> {
                 ),
             ],
           ),
-          Selector<ScooterService, ({String? pendingName, bool isNavigating})>(
+          Selector<ScooterService, ({String? pendingName, String? activeName, bool isNavigating})>(
             selector: (_, s) => (
               pendingName: s.pendingNavigation?.name,
+              activeName: s.activeNavigation?.name,
               isNavigating: s.vehicle.navigationActive == true,
             ),
             builder: (context, state, _) {
@@ -570,6 +573,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
                 child: _navigationStatusCard(
                   isNavigating: state.isNavigating,
                   pendingName: state.pendingName,
+                  activeName: state.activeName,
                 ),
               );
             },
@@ -774,17 +778,25 @@ class _NavigationScreenState extends State<NavigationScreen> {
     );
   }
 
-  Widget _navigationStatusCard({required bool isNavigating, String? pendingName}) {
+  Future<void> _cancelActiveNavigation(ScooterService service) async {
+    try {
+      await cancelNavigationCommand(
+        service.myScooter,
+        service.characteristicRepository,
+      );
+    } finally {
+      service.setActiveNavigation(null);
+    }
+  }
+
+  Widget _navigationStatusCard({required bool isNavigating, String? pendingName, String? activeName}) {
     final service = context.read<ScooterService>();
     return Dismissible(
       key: const Key("navigation_status_card"),
       direction: DismissDirection.horizontal,
       onDismissed: (_) {
         if (isNavigating) {
-          cancelNavigationCommand(
-            service.myScooter,
-            service.characteristicRepository,
-          );
+          _cancelActiveNavigation(service);
         } else {
           service.setPendingNavigation(null);
         }
@@ -794,9 +806,11 @@ class _NavigationScreenState extends State<NavigationScreen> {
         child: ListTile(
           leading: Icon(isNavigating ? Icons.navigation : Icons.schedule, color: Theme.of(context).colorScheme.surface),
           title: Text(
-            isNavigating
-                ? FlutterI18n.translate(context, "nav_status_active_title")
-                : FlutterI18n.translate(context, "nav_status_pending_title"),
+            isNavigating && activeName?.trim().isNotEmpty == true
+                ? activeName!
+                : isNavigating
+                    ? FlutterI18n.translate(context, "nav_status_active_title")
+                    : FlutterI18n.translate(context, "nav_status_pending_title"),
             style: TextStyle(color: Theme.of(context).colorScheme.surface),
           ),
           subtitle: Text(
@@ -808,15 +822,18 @@ class _NavigationScreenState extends State<NavigationScreen> {
             style: TextStyle(
                 color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7), fontStyle: FontStyle.italic),
           ),
-          trailing: IconButton(
-            icon: Icon(Icons.close, color: Theme.of(context).colorScheme.surface),
-            tooltip: FlutterI18n.translate(context, "cancel"),
+          trailing: TextButton.icon(
+            style: TextButton.styleFrom(
+              foregroundColor:
+                  isNavigating ? Theme.of(context).colorScheme.error : Theme.of(context).colorScheme.surface,
+            ),
+            icon: Icon(isNavigating ? Icons.stop_circle_outlined : Icons.close, size: 20),
+            label: Text(
+              FlutterI18n.translate(context, isNavigating ? "nav_stop_button" : "cancel"),
+            ),
             onPressed: () {
               if (isNavigating) {
-                cancelNavigationCommand(
-                  service.myScooter,
-                  service.characteristicRepository,
-                );
+                _cancelActiveNavigation(service);
               } else {
                 service.setPendingNavigation(null);
               }

--- a/lib/scooter_service.dart
+++ b/lib/scooter_service.dart
@@ -54,6 +54,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
 
   BluetoothDevice? myScooter; // reserved for a connected scooter!
   NavDestination? _pendingNavigation;
+  NavDestination? _activeNavigation;
   bool _foundSth = false; // whether we've found a scooter yet
   bool _autoRestarting = false;
   String? _targetScooterId; // specific scooter ID to connect to during auto-restart
@@ -253,6 +254,12 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
 
   // PENDING NAVIGATION
   NavDestination? get pendingNavigation => _pendingNavigation;
+  NavDestination? get activeNavigation => _activeNavigation;
+
+  void setActiveNavigation(NavDestination? destination) {
+    _activeNavigation = destination;
+    notifyListeners();
+  }
 
   Future<void> setPendingNavigation(NavDestination? dest) async {
     _pendingNavigation = dest;
@@ -275,6 +282,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
       );
 
       log.info('Pending navigation dispatched to ${_pendingNavigation!.name}');
+      setActiveNavigation(_pendingNavigation);
       await setPendingNavigation(null);
     } catch (e) {
       log.warning('Pending navigation dispatch failed: $e');
@@ -677,6 +685,7 @@ class ScooterService with ChangeNotifier, WidgetsBindingObserver {
         notifyListeners();
       },
       onNavigationChanged: () {
+        if (vehicle.navigationActive != true) _activeNavigation = null;
         ping();
         notifyListeners();
       },


### PR DESCRIPTION
## Summary
- remember the destination after immediate or queued navigation starts
- show the known destination in the active navigation card
- clear the remembered destination when navigation ends or is cancelled
- replace the ambiguous close icon with an explicit localized Stop button

Navigation started outside the app continues to use the generic active status because the protocol does not expose its target.

## Validation
- `flutter analyze`
- `flutter test` (93 tests)
- locale JSON validation
- `git diff --check`