### PR TITLE
Open navigation from a pull-up drawer

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -433,6 +433,7 @@
     "ls_keycard_read_error": "Karten-UID konnte nicht gelesen werden. Bitte versuche es erneut.",
     "ls_keycard_already_registered": "Diese Karte ist bereits registriert.",
     "ls_keycard_mismatch": "Diese Karte ist möglicherweise nicht kompatibel oder es ist ein Fehler beim Lesen aufgetreten. Bitte versuche es erneut.",
+    "home_navigation_hint": "Für Navigation nach oben wischen",
     "nav_title": "Navigation",
     "nav_timeout_cached": "Verbindung unterbrochen. Letzte bekannte Ziele werden angezeigt.",
     "nav_load_error": "Ziele konnten nicht geladen werden: {error}",

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -475,7 +475,7 @@
     "nav_disconnected_title": "Roller nicht verbunden",
     "nav_disconnected_subtitle": "Verbinde deinen Roller, um gespeicherte Ziele zu sehen.",
     "nav_empty_title": "Keine gespeicherten Ziele",
-    "nav_empty_subtitle": "Zum Aktualisieren nach unten ziehen.",
+    "nav_empty_subtitle": "Suche nach einer Adresse, um ein Ziel hinzuzufügen.",
     "ls_keycard_ios_unsupported": "Karte nicht erkannt? Stelle sicher, dass sie von iOS unterstützt wird (MIFARE, ISO 7816, ISO 15693).",
     "ls_keycard_add_success": "Keycard erfolgreich hinzugefügt!",
     "ls_settings_ota_title": "Firmware-Update",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -433,6 +433,7 @@
     "ls_keycard_read_error": "Could not read card UID. Please try again.",
     "ls_keycard_already_registered": "This card is already registered.",
     "ls_keycard_mismatch": "This card might not be compatible or there was an error reading it. Please try again.",
+    "home_navigation_hint": "Swipe up for navigation",
     "nav_title": "Navigation",
     "nav_timeout_cached": "Connection timed out, showing last known destinations.",
     "nav_load_error": "Failed to load destinations: {error}",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -475,7 +475,7 @@
     "nav_disconnected_title": "Scooter not connected",
     "nav_disconnected_subtitle": "Connect to your scooter to see saved destinations.",
     "nav_empty_title": "No saved destinations",
-    "nav_empty_subtitle": "Pull down to refresh.",
+    "nav_empty_subtitle": "Search for an address to add a destination.",
     "ls_keycard_ios_unsupported": "Couldn't detect your card? Make sure it is supported by iOS (MIFARE, ISO 7816, ISO 15693).",
     "ls_keycard_add_success": "Keycard added successfully!",
     "ls_settings_ota_title": "Firmware update",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -475,7 +475,7 @@
     "nav_disconnected_title": "Scooter non connecté",
     "nav_disconnected_subtitle": "Connectez votre scooter pour voir les destinations enregistrées.",
     "nav_empty_title": "Aucune destination enregistrée",
-    "nav_empty_subtitle": "Tirez vers le bas pour actualiser.",
+    "nav_empty_subtitle": "Recherchez une adresse pour ajouter une destination.",
     "ls_keycard_ios_unsupported": "Carte non détectée ? Assurez-vous qu'elle est prise en charge par iOS (MIFARE, ISO 7816, ISO 15693).",
     "ls_keycard_add_success": "Carte-clé ajoutée avec succès !",
     "ls_settings_ota_title": "Mise à jour du firmware",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -433,6 +433,7 @@
     "ls_keycard_read_error": "Impossible de lire l'UID de la carte. Veuillez réessayer.",
     "ls_keycard_already_registered": "Cette carte est déjà enregistrée.",
     "ls_keycard_mismatch": "Cette carte n'est peut-être pas compatible ou une erreur s'est produite lors de la lecture. Veuillez réessayer.",
+    "home_navigation_hint": "Balayez vers le haut pour la navigation",
     "nav_title": "Navigation",
     "nav_timeout_cached": "Connexion expirée, affichage des dernières destinations connues.",
     "nav_load_error": "Impossible de charger les destinations : {error}",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -433,6 +433,7 @@
     "ls_keycard_read_error": "Kaart-UID kon niet worden gelezen. Probeer het opnieuw.",
     "ls_keycard_already_registered": "Deze kaart is al geregistreerd.",
     "ls_keycard_mismatch": "Deze kaart is mogelijk niet compatibel of er is een fout opgetreden bij het lezen. Probeer het opnieuw.",
+    "home_navigation_hint": "Veeg omhoog voor navigatie",
     "nav_title": "Navigatie",
     "nav_timeout_cached": "Verbinding verbroken, laatste bekende bestemmingen worden weergegeven.",
     "nav_load_error": "Bestemmingen konden niet worden geladen: {error}",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -475,7 +475,7 @@
     "nav_disconnected_title": "Scooter niet verbonden",
     "nav_disconnected_subtitle": "Verbind je scooter om opgeslagen bestemmingen te zien.",
     "nav_empty_title": "Geen opgeslagen bestemmingen",
-    "nav_empty_subtitle": "Veeg omlaag om te vernieuwen.",
+    "nav_empty_subtitle": "Zoek een adres om een bestemming toe te voegen.",
     "ls_keycard_ios_unsupported": "Kaart niet gedetecteerd? Zorg ervoor dat deze wordt ondersteund door iOS (MIFARE, ISO 7816, ISO 15693).",
     "ls_keycard_add_success": "Keycard succesvol toegevoegd!",
     "ls_settings_ota_title": "Firmware-update",

--- a/assets/i18n/pi.json
+++ b/assets/i18n/pi.json
@@ -455,7 +455,7 @@
     "nav_disconnected_title": "Scooter not in sight!",
     "nav_disconnected_subtitle": "Connect yer scooter to see saved ports.",
     "nav_empty_title": "No saved destinations",
-    "nav_empty_subtitle": "Pull down to search the seas.",
+    "nav_empty_subtitle": "Search for a port to add a destination.",
     "ls_keycard_ios_unsupported": "Couldn't detect yer card, matey? Make sure it be plunderable by iOS (MIFARE, ISO 7816, ISO 15693).",
     "ls_keycard_add_success": "Keycard added to yer crew, arrr!",
     "ls_settings_ota_title": "Firmware refit",

--- a/assets/i18n/pi.json
+++ b/assets/i18n/pi.json
@@ -413,6 +413,7 @@
     "ls_keycard_read_error": "Couldn't read the card's secret, arr. Try again, matey!",
     "ls_keycard_already_registered": "This card's already in the log, arr!",
     "ls_keycard_mismatch": "This card might not be seaworthy, or there were stormy seas while reading it. Try again, arr!",
+    "home_navigation_hint": "Swipe up to chart yer course",
     "nav_title": "Navigation",
     "nav_timeout_cached": "Connection timed out, showin' last known ports, arr.",
     "nav_load_error": "Failed to haul up destinations: {error}",

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -46,6 +46,7 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   final log = Logger('HomeScreen');
   bool _hazards = false;
+  double _navigationDragDistance = 0;
 
   // Seasonal
   bool _snowing = false;
@@ -61,7 +62,6 @@ class _HomeScreenState extends State<HomeScreen> {
       redirectOrStart();
     }
   }
-
 
   Future<void> _startSeasonal() async {
     SharedPreferencesAsync prefs = SharedPreferencesAsync();
@@ -171,362 +171,388 @@ class _HomeScreenState extends State<HomeScreen> {
                   duration: Duration(milliseconds: 500),
                   child: GrassScape(),
                 ),
-              SafeArea(
-                child: Stack(
-                  children: [
-                    Positioned(
-                      top: 0,
-                      left: 8,
-                      child: IconButton(
-                        icon: const Icon(Icons.help_outline),
-                        onPressed: () => Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => const SupportScreen(),
-                          ),
-                        ),
-                      ),
-                    ),
-                    Positioned(
-                      top: 0,
-                      right: 8,
-                      child: IconButton(
-                        icon: const Icon(Icons.settings_outlined),
-                        onPressed: () => Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => const SettingsScreen(),
-                          ),
-                        ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 40, bottom: 20),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        mainAxisSize: MainAxisSize.max,
-                        children: [
-                          Padding(
-                            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                            child: Material(
-                              color: Colors.transparent,
-                              child: InkWell(
-                                borderRadius: BorderRadius.circular(8),
-                                onTap: () => Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => const ScooterScreen(),
-                                  ),
-                                ),
-                                // // Hidden for stable release, but useful for various debugging
-                                // onLongPress: () {
-                                //   Navigator.push(
-                                //     context,
-                                //     MaterialPageRoute(
-                                //       builder: (context) => const LsKeycardScreen(),
-                                //     ),
-                                //   );
-                                // },
-                                child: Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    SizedBox(
-                                      width: context.select(
-                                        (ScooterService service) => service.connected,
-                                      )
-                                          ? 32
-                                          : 0,
-                                    ),
-                                    Flexible(
-                                      child: Text(
-                                        context.select<ScooterService, String?>(
-                                              (service) => service.identity.name,
-                                            ) ??
-                                            FlutterI18n.translate(
-                                              context,
-                                              "stats_no_name",
-                                            ),
-                                        style: Theme.of(context).textTheme.headlineLarge?.copyWith(height: 1.1),
-                                        textAlign: TextAlign.center,
-                                        maxLines: 2,
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                    ),
-                                    const SizedBox(width: 16),
-                                    const Icon(
-                                      Icons.arrow_forward_ios_rounded,
-                                      size: 16,
-                                    ),
-                                  ],
-                                ),
-                              ),
+              GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onVerticalDragStart: (_) => _navigationDragDistance = 0,
+                onVerticalDragUpdate: (details) {
+                  _navigationDragDistance = (_navigationDragDistance - details.delta.dy).clamp(0, double.infinity);
+                },
+                onVerticalDragEnd: (details) {
+                  final velocity = details.primaryVelocity ?? 0;
+                  if (_navigationDragDistance >= 96 || (_navigationDragDistance >= 48 && velocity < -500)) {
+                    _openNavigationSheet();
+                  }
+                  _navigationDragDistance = 0;
+                },
+                onVerticalDragCancel: () => _navigationDragDistance = 0,
+                child: SafeArea(
+                  child: Stack(
+                    children: [
+                      Positioned(
+                        top: 0,
+                        left: 8,
+                        child: IconButton(
+                          icon: const Icon(Icons.help_outline),
+                          onPressed: () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => const SupportScreen(),
                             ),
                           ),
-                          const StatusText(),
-                          if (context.select<ScooterService, String?>(
-                                    (service) => service.identity.name,
-                                  ) !=
-                                  null &&
-                              context.select<ScooterService, String?>(
-                                    (service) => service.identity.name,
-                                  ) !=
-                                  FlutterI18n.translate(
+                        ),
+                      ),
+                      Positioned(
+                        top: 0,
+                        right: 8,
+                        child: IconButton(
+                          icon: const Icon(Icons.settings_outlined),
+                          onPressed: () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => const SettingsScreen(),
+                            ),
+                          ),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 40, bottom: 20),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          mainAxisSize: MainAxisSize.max,
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                              child: Material(
+                                color: Colors.transparent,
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(8),
+                                  onTap: () => Navigator.push(
                                     context,
-                                    "stats_no_name",
-                                  ) &&
-                              (context.select<ScooterService, int?>(
-                                        (service) => service.battery.primarySOC,
-                                      ) !=
-                                      null ||
-                                  context.select<ScooterService, int?>(
-                                        (service) => service.battery.secondarySOC,
-                                      ) !=
-                                      null))
-                            Material(
-                              borderRadius: BorderRadius.circular(8),
-                              color: Colors.transparent,
-                              child: InkWell(
-                                borderRadius: BorderRadius.circular(8),
-                                onTap: () => Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => const BatteryScreen(),
+                                    MaterialPageRoute(
+                                      builder: (context) => const ScooterScreen(),
+                                    ),
                                   ),
-                                ),
-                                child: Container(
-                                  padding: const EdgeInsets.all(16.0),
+                                  // // Hidden for stable release, but useful for various debugging
+                                  // onLongPress: () {
+                                  //   Navigator.push(
+                                  //     context,
+                                  //     MaterialPageRoute(
+                                  //       builder: (context) => const LsKeycardScreen(),
+                                  //     ),
+                                  //   );
+                                  // },
                                   child: Row(
-                                    mainAxisSize: MainAxisSize.min,
                                     mainAxisAlignment: MainAxisAlignment.center,
+                                    mainAxisSize: MainAxisSize.min,
                                     children: [
-                                      const SizedBox(width: 16),
-                                      BatteryBars(
-                                        primarySOC: context.select<ScooterService, int?>(
-                                          (service) => service.battery.primarySOC,
-                                        ),
-                                        secondarySOC: context.select<ScooterService, int?>(
-                                          (service) => service.battery.secondarySOC,
-                                        ),
-                                        dataIsOld: context.select<ScooterService, DateTime?>(
-                                                  (service) => service.identity.lastPing,
-                                                ) ==
-                                                null
-                                            ? true
-                                            : context
-                                                    .select<ScooterService, DateTime?>(
-                                                      (service) => service.identity.lastPing,
-                                                    )!
-                                                    .difference(
-                                                      DateTime.now(),
-                                                    )
-                                                    .inMinutes
-                                                    .abs() >
-                                                5,
+                                      SizedBox(
+                                        width: context.select(
+                                          (ScooterService service) => service.connected,
+                                        )
+                                            ? 32
+                                            : 0,
                                       ),
-                                      const SizedBox(width: 8),
+                                      Flexible(
+                                        child: Text(
+                                          context.select<ScooterService, String?>(
+                                                (service) => service.identity.name,
+                                              ) ??
+                                              FlutterI18n.translate(
+                                                context,
+                                                "stats_no_name",
+                                              ),
+                                          style: Theme.of(context).textTheme.headlineLarge?.copyWith(height: 1.1),
+                                          textAlign: TextAlign.center,
+                                          maxLines: 2,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      ),
+                                      const SizedBox(width: 16),
                                       const Icon(
                                         Icons.arrow_forward_ios_rounded,
-                                        size: 12,
+                                        size: 16,
                                       ),
                                     ],
                                   ),
                                 ),
                               ),
                             ),
-                          Expanded(
-                            child: Stack(
-                              children: [
-                                Positioned.fill(
-                                  child: ScooterVisual(
-                                    color: context.select<ScooterService, int?>(
-                                          (service) => service.identity.color,
-                                        ) ??
-                                        1,
-                                    state: context.select(
-                                      (ScooterService service) => service.state,
+                            const StatusText(),
+                            if (context.select<ScooterService, String?>(
+                                      (service) => service.identity.name,
+                                    ) !=
+                                    null &&
+                                context.select<ScooterService, String?>(
+                                      (service) => service.identity.name,
+                                    ) !=
+                                    FlutterI18n.translate(
+                                      context,
+                                      "stats_no_name",
+                                    ) &&
+                                (context.select<ScooterService, int?>(
+                                          (service) => service.battery.primarySOC,
+                                        ) !=
+                                        null ||
+                                    context.select<ScooterService, int?>(
+                                          (service) => service.battery.secondarySOC,
+                                        ) !=
+                                        null))
+                              Material(
+                                borderRadius: BorderRadius.circular(8),
+                                color: Colors.transparent,
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(8),
+                                  onTap: () => Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (context) => const BatteryScreen(),
                                     ),
-                                    scanning: context.select(
-                                      (ScooterService service) => service.scanning,
+                                  ),
+                                  child: Container(
+                                    padding: const EdgeInsets.all(16.0),
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      mainAxisAlignment: MainAxisAlignment.center,
+                                      children: [
+                                        const SizedBox(width: 16),
+                                        BatteryBars(
+                                          primarySOC: context.select<ScooterService, int?>(
+                                            (service) => service.battery.primarySOC,
+                                          ),
+                                          secondarySOC: context.select<ScooterService, int?>(
+                                            (service) => service.battery.secondarySOC,
+                                          ),
+                                          dataIsOld: context.select<ScooterService, DateTime?>(
+                                                    (service) => service.identity.lastPing,
+                                                  ) ==
+                                                  null
+                                              ? true
+                                              : context
+                                                      .select<ScooterService, DateTime?>(
+                                                        (service) => service.identity.lastPing,
+                                                      )!
+                                                      .difference(
+                                                        DateTime.now(),
+                                                      )
+                                                      .inMinutes
+                                                      .abs() >
+                                                  5,
+                                        ),
+                                        const SizedBox(width: 8),
+                                        const Icon(
+                                          Icons.arrow_forward_ios_rounded,
+                                          size: 12,
+                                        ),
+                                      ],
                                     ),
-                                    blinkerLeft: _hazards,
-                                    blinkerRight: _hazards,
-                                    winter: _snowing,
-                                    aprilFools: _forceHover,
-                                    halloween: _fall && context.isDarkMode,
                                   ),
                                 ),
-                                Selector<ScooterService, ({bool? isLibrescoot, bool hasNavigation})>(
+                              ),
+                            Expanded(
+                              child: ScooterVisual(
+                                color: context.select<ScooterService, int?>(
+                                      (service) => service.identity.color,
+                                    ) ??
+                                    1,
+                                state: context.select(
+                                  (ScooterService service) => service.state,
+                                ),
+                                scanning: context.select(
+                                  (ScooterService service) => service.scanning,
+                                ),
+                                blinkerLeft: _hazards,
+                                blinkerRight: _hazards,
+                                winter: _snowing,
+                                aprilFools: _forceHover,
+                                halloween: _fall && context.isDarkMode,
+                              ),
+                            ),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              mainAxisSize: MainAxisSize.max,
+                              children: [
+                                const SeatButton(),
+                                Selector<ScooterService, ScooterState?>(
+                                  selector: (context, service) => service.state,
+                                  builder: (context, state, _) {
+                                    return Expanded(
+                                      child: ScooterPowerButton(
+                                        action: state != null && state.isReadyForLockChange
+                                            ? (state.isOn
+                                                ? () async {
+                                                    if (context.read<ScooterService>().vehicle.seatClosed == false) {
+                                                      bool overrideSeat = await showSeatWarning() == true;
+                                                      if (!overrideSeat) {
+                                                        return;
+                                                      }
+                                                    }
+                                                    try {
+                                                      if (!context.mounted) return;
+                                                      await context.read<ScooterService>().lock();
+                                                      if (!context.mounted) return;
+                                                      if (context.read<ScooterService>().hazardLocking) {
+                                                        _flashHazards(1);
+                                                      }
+                                                    } on HandlebarLockException catch (_) {
+                                                      log.warning(
+                                                        "Handlebars are still unlocked, showing alert",
+                                                      );
+                                                      showHandlebarWarning(
+                                                        didNotUnlock: false,
+                                                      );
+                                                    } catch (e, stack) {
+                                                      log.severe(
+                                                        "Problem opening the seat",
+                                                        e,
+                                                        stack,
+                                                      );
+                                                      Fluttertoast.showToast(
+                                                        msg: e.toString(),
+                                                      );
+                                                    }
+                                                  }
+                                                : (state == ScooterState.standby
+                                                    ? () async {
+                                                        try {
+                                                          await context.read<ScooterService>().unlock();
+                                                          if (context.mounted &&
+                                                              context.read<ScooterService>().hazardLocking) {
+                                                            _flashHazards(2);
+                                                          }
+                                                        } on HandlebarLockException catch (_) {
+                                                          log.warning(
+                                                            "Handlebars are still locked, showing alert",
+                                                          );
+                                                          showHandlebarWarning(
+                                                            didNotUnlock: true,
+                                                          );
+                                                        }
+                                                      }
+                                                    : (state == ScooterState.standby
+                                                        ? () {
+                                                            context.read<ScooterService>().unlock();
+                                                            // TODO: Flash hazards in visual
+                                                          }
+                                                        : context.read<ScooterService>().wakeUpAndUnlock)))
+                                            : null,
+                                        icon: state != null && state.isOn ? Icons.lock_open : Icons.lock_outline,
+                                        label: state != null && state.isOn
+                                            ? FlutterI18n.translate(
+                                                context,
+                                                "home_lock_button",
+                                              )
+                                            : FlutterI18n.translate(
+                                                context,
+                                                "home_unlock_button",
+                                              ),
+                                      ),
+                                    );
+                                  },
+                                ),
+                                Selector<ScooterService, ({bool scanning, bool connected})>(
                                   selector: (context, service) => (
-                                    isLibrescoot: service.identity.isLibrescoot,
-                                    hasNavigation:
-                                        service.navigationActive == true || service.pendingNavigation != null,
+                                    scanning: service.scanning,
+                                    connected: service.connected,
                                   ),
-                                  builder: (context, value, child) {
-                                    if (value.isLibrescoot != true) return const SizedBox.shrink();
-                                    return Positioned(
-                                      right: 36,
-                                      bottom: 4,
+                                  builder: (context, state, _) {
+                                    return Expanded(
                                       child: ScooterActionButton(
-                                        icon: Icons.navigation_outlined,
-                                        label: FlutterI18n.translate(context, 'nav_title'),
-                                        showBubble: value.hasNavigation,
-                                        onPressed: () => Navigator.push(
-                                          context,
-                                          MaterialPageRoute(
-                                            settings: const RouteSettings(name: 'navigation'),
-                                            builder: (context) => const NavigationScreen(),
-                                          ),
-                                        ),
+                                        onPressed: !state.scanning
+                                            ? () {
+                                                if (!state.connected) {
+                                                  log.info(
+                                                    "Manually reconnecting...",
+                                                  );
+                                                  try {
+                                                    context.read<ScooterService>().start();
+                                                  } catch (e, stack) {
+                                                    log.severe(
+                                                      "Reconnect button failed",
+                                                      e,
+                                                      stack,
+                                                    );
+                                                  }
+                                                } else {
+                                                  showModalBottomSheet<void>(
+                                                    context: context,
+                                                    showDragHandle: true,
+                                                    isScrollControlled: true,
+                                                    builder: (BuildContext context) {
+                                                      return ControlSheet();
+                                                    },
+                                                  );
+                                                }
+                                              }
+                                            : null,
+                                        icon: !state.connected ? Icons.refresh_rounded : Icons.more_vert_rounded,
+                                        label: !state.connected
+                                            ? FlutterI18n.translate(
+                                                context,
+                                                "home_reconnect_button",
+                                              )
+                                            : FlutterI18n.translate(
+                                                context,
+                                                "home_controls_button",
+                                              ),
                                       ),
                                     );
                                   },
                                 ),
                               ],
                             ),
-                          ),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            mainAxisSize: MainAxisSize.max,
-                            children: [
-                              const SeatButton(),
-                              Selector<ScooterService, ScooterState?>(
-                                selector: (context, service) => service.state,
-                                builder: (context, state, _) {
-                                  return Expanded(
-                                    child: ScooterPowerButton(
-                                      action: state != null && state.isReadyForLockChange
-                                          ? (state.isOn
-                                              ? () async {
-                                                  if (context.read<ScooterService>().vehicle.seatClosed == false) {
-                                                    bool overrideSeat = await showSeatWarning() == true;
-                                                    if (!overrideSeat) {
-                                                      return;
-                                                    }
-                                                  }
-                                                  try {
-                                                    if (!context.mounted) return;
-                                                    await context.read<ScooterService>().lock();
-                                                    if (!context.mounted) return;
-                                                    if (context.read<ScooterService>().hazardLocking) {
-                                                      _flashHazards(1);
-                                                    }
-                                                  } on HandlebarLockException catch (_) {
-                                                    log.warning(
-                                                      "Handlebars are still unlocked, showing alert",
-                                                    );
-                                                    showHandlebarWarning(
-                                                      didNotUnlock: false,
-                                                    );
-                                                  } catch (e, stack) {
-                                                    log.severe(
-                                                      "Problem opening the seat",
-                                                      e,
-                                                      stack,
-                                                    );
-                                                    Fluttertoast.showToast(
-                                                      msg: e.toString(),
-                                                    );
-                                                  }
-                                                }
-                                              : (state == ScooterState.standby
-                                                  ? () async {
-                                                      try {
-                                                        await context.read<ScooterService>().unlock();
-                                                        if (context.mounted &&
-                                                            context.read<ScooterService>().hazardLocking) {
-                                                          _flashHazards(2);
-                                                        }
-                                                      } on HandlebarLockException catch (_) {
-                                                        log.warning(
-                                                          "Handlebars are still locked, showing alert",
-                                                        );
-                                                        showHandlebarWarning(
-                                                          didNotUnlock: true,
-                                                        );
-                                                      }
-                                                    }
-                                                  : (state == ScooterState.standby
-                                                      ? () {
-                                                          context.read<ScooterService>().unlock();
-                                                          // TODO: Flash hazards in visual
-                                                        }
-                                                      : context.read<ScooterService>().wakeUpAndUnlock)))
-                                          : null,
-                                      icon: state != null && state.isOn ? Icons.lock_open : Icons.lock_outline,
-                                      label: state != null && state.isOn
-                                          ? FlutterI18n.translate(
-                                              context,
-                                              "home_lock_button",
-                                            )
-                                          : FlutterI18n.translate(
-                                              context,
-                                              "home_unlock_button",
-                                            ),
-                                    ),
-                                  );
-                                },
-                              ),
-                              Selector<ScooterService, ({bool scanning, bool connected})>(
-                                selector: (context, service) => (
-                                  scanning: service.scanning,
-                                  connected: service.connected,
-                                ),
-                                builder: (context, state, _) {
-                                  return Expanded(
-                                    child: ScooterActionButton(
-                                      onPressed: !state.scanning
-                                          ? () {
-                                              if (!state.connected) {
-                                                log.info(
-                                                  "Manually reconnecting...",
-                                                );
-                                                try {
-                                                  context.read<ScooterService>().start();
-                                                } catch (e, stack) {
-                                                  log.severe(
-                                                    "Reconnect button failed",
-                                                    e,
-                                                    stack,
-                                                  );
-                                                }
-                                              } else {
-                                                showModalBottomSheet<void>(
-                                                  context: context,
-                                                  showDragHandle: true,
-                                                  isScrollControlled: true,
-                                                  builder: (BuildContext context) {
-                                                    return ControlSheet();
-                                                  },
-                                                );
-                                              }
-                                            }
-                                          : null,
-                                      icon: !state.connected ? Icons.refresh_rounded : Icons.more_vert_rounded,
-                                      label: !state.connected
-                                          ? FlutterI18n.translate(
-                                              context,
-                                              "home_reconnect_button",
-                                            )
-                                          : FlutterI18n.translate(
-                                              context,
-                                              "home_controls_button",
-                                            ),
-                                    ),
-                                  );
-                                },
-                              ),
-                            ],
-                          ),
-                        ],
+                            _navigationCue(),
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _navigationCue() {
+    return Selector<ScooterService, bool>(
+      selector: (context, service) => service.identity.isLibrescoot == true || kDebugMode,
+      builder: (context, isLibrescoot, child) {
+        if (!isLibrescoot) return const SizedBox.shrink();
+        return Semantics(
+          button: true,
+          label: FlutterI18n.translate(context, 'nav_title'),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: _openNavigationSheet,
+            child: SizedBox(
+              height: 28,
+              width: double.infinity,
+              child: Center(
+                child: Icon(
+                  Icons.keyboard_arrow_up_rounded,
+                  size: 22,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _openNavigationSheet() {
+    if (context.read<ScooterService>().identity.isLibrescoot != true && !kDebugMode) return;
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => const FractionallySizedBox(
+        heightFactor: 0.9,
+        child: NavigationScreen(embedded: true),
       ),
     );
   }

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -215,7 +215,7 @@ class _HomeScreenState extends State<HomeScreen> {
                         ),
                       ),
                       Padding(
-                        padding: const EdgeInsets.only(top: 40, bottom: 20),
+                        padding: const EdgeInsets.only(top: 40, bottom: 8),
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           mainAxisSize: MainAxisSize.max,
@@ -543,7 +543,7 @@ class _HomeScreenState extends State<HomeScreen> {
             child: ConstrainedBox(
               constraints: const BoxConstraints(minWidth: double.infinity, minHeight: 48),
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -538,10 +538,11 @@ class _HomeScreenState extends State<HomeScreen> {
             behavior: HitTestBehavior.opaque,
             onTap: _openNavigationSheet,
             child: ConstrainedBox(
-              constraints: const BoxConstraints(minHeight: 48),
+              constraints: const BoxConstraints(minWidth: double.infinity, minHeight: 48),
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: Row(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Badge(
@@ -553,14 +554,12 @@ class _HomeScreenState extends State<HomeScreen> {
                         color: Theme.of(context).colorScheme.onSurfaceVariant,
                       ),
                     ),
-                    const SizedBox(width: 8),
-                    Flexible(
-                      child: Text(
-                        FlutterI18n.translate(context, 'nav_title'),
-                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                              color: Theme.of(context).colorScheme.onSurfaceVariant,
-                            ),
-                      ),
+                    Text(
+                      FlutterI18n.translate(context, 'nav_title'),
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
                     ),
                   ],
                 ),

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -500,7 +500,10 @@ class _HomeScreenState extends State<HomeScreen> {
                                 ),
                               ],
                             ),
-                            _navigationCue(),
+                            Padding(
+                              padding: const EdgeInsets.only(top: 12),
+                              child: _navigationCue(),
+                            ),
                           ],
                         ),
                       ),
@@ -548,14 +551,21 @@ class _HomeScreenState extends State<HomeScreen> {
                     Badge(
                       isLabelVisible: state.active || state.pending,
                       backgroundColor: Theme.of(context).colorScheme.primary,
-                      child: Icon(
-                        Icons.keyboard_arrow_up_rounded,
-                        size: 22,
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      child: SizedBox(
+                        height: 14,
+                        width: 22,
+                        child: OverflowBox(
+                          maxHeight: 22,
+                          child: Icon(
+                            Icons.keyboard_arrow_up_rounded,
+                            size: 22,
+                            color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                        ),
                       ),
                     ),
                     Text(
-                      FlutterI18n.translate(context, 'nav_title'),
+                      FlutterI18n.translate(context, 'home_navigation_hint'),
                       textAlign: TextAlign.center,
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
                             color: Theme.of(context).colorScheme.onSurfaceVariant,

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -516,24 +516,53 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Widget _navigationCue() {
-    return Selector<ScooterService, bool>(
-      selector: (context, service) => service.identity.isLibrescoot == true || kDebugMode,
-      builder: (context, isLibrescoot, child) {
-        if (!isLibrescoot) return const SizedBox.shrink();
+    return Selector<ScooterService, ({bool visible, bool active, bool pending})>(
+      selector: (context, service) => (
+        visible: service.identity.isLibrescoot == true || kDebugMode,
+        active: service.vehicle.navigationActive == true,
+        pending: service.pendingNavigation != null,
+      ),
+      builder: (context, state, child) {
+        if (!state.visible) return const SizedBox.shrink();
         return Semantics(
           button: true,
           label: FlutterI18n.translate(context, 'nav_title'),
+          value: state.active
+              ? FlutterI18n.translate(context, 'nav_status_active_title')
+              : state.pending
+                  ? FlutterI18n.translate(context, 'nav_status_pending_title')
+                  : null,
+          excludeSemantics: true,
+          onTap: _openNavigationSheet,
           child: GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: _openNavigationSheet,
-            child: SizedBox(
-              height: 28,
-              width: double.infinity,
-              child: Center(
-                child: Icon(
-                  Icons.keyboard_arrow_up_rounded,
-                  size: 22,
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 48),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Badge(
+                      isLabelVisible: state.active || state.pending,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                      child: Icon(
+                        Icons.keyboard_arrow_up_rounded,
+                        size: 22,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Flexible(
+                      child: Text(
+                        FlutterI18n.translate(context, 'nav_title'),
+                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                              color: Theme.of(context).colorScheme.onSurfaceVariant,
+                            ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
@@ -549,10 +578,12 @@ class _HomeScreenState extends State<HomeScreen> {
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
-      backgroundColor: Colors.transparent,
-      builder: (context) => const FractionallySizedBox(
-        heightFactor: 0.9,
-        child: NavigationScreen(embedded: true),
+      showDragHandle: true,
+      clipBehavior: Clip.antiAlias,
+      builder: (context) => SizedBox(
+        // The native drag handle occupies the remaining 48 logical pixels.
+        height: MediaQuery.sizeOf(context).height * 0.9 - kMinInteractiveDimension,
+        child: const NavigationScreen(embedded: true),
       ),
     );
   }

--- a/lib/navigation_screen.dart
+++ b/lib/navigation_screen.dart
@@ -18,7 +18,9 @@ import '../service/ble_commands.dart';
 
 class NavigationScreen extends StatefulWidget {
   final NavDestination? initialDestination;
-  const NavigationScreen({this.initialDestination, super.key});
+  final bool embedded;
+
+  const NavigationScreen({this.initialDestination, this.embedded = false, super.key});
 
   @override
   State<NavigationScreen> createState() => _NavigationScreenState();
@@ -30,6 +32,8 @@ class _NavigationScreenState extends State<NavigationScreen> {
   bool _osmConsent = true;
   bool _initialLoad = true;
   bool _showingCached = false;
+  double _dismissPullDistance = 0;
+  bool _dismissTriggered = false;
   final FocusNode _searchFocusNode = FocusNode();
 
   @override
@@ -508,9 +512,114 @@ class _NavigationScreenState extends State<NavigationScreen> {
     }
   }
 
+  bool _handleDismissPull(ScrollNotification notification) {
+    if (!widget.embedded) return false;
+
+    if (notification is ScrollStartNotification) {
+      _dismissPullDistance = 0;
+      _dismissTriggered = false;
+    } else if (notification is OverscrollNotification &&
+        notification.metrics.pixels <= notification.metrics.minScrollExtent &&
+        notification.overscroll < 0) {
+      _dismissPullDistance += -notification.overscroll;
+      if (_dismissPullDistance >= 48 && !_dismissTriggered) {
+        _dismissTriggered = true;
+        Navigator.of(context).maybePop();
+      }
+    } else if (notification is ScrollEndNotification) {
+      _dismissPullDistance = 0;
+      _dismissTriggered = false;
+    }
+    return false;
+  }
+
+  Widget _pullDownDismiss(Widget child) {
+    return NotificationListener<ScrollNotification>(
+      onNotification: _handleDismissPull,
+      child: child,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final connected = context.select<ScooterService, bool>((s) => s.connected);
+    final content = Stack(
+      children: [
+        Column(
+          children: [
+            if (_osmConsent) _searchField(),
+            const SizedBox(height: 8),
+            if (_loading && _initialLoad)
+              const Expanded(child: _DestinationsLoading())
+            else if (_destinations.isEmpty && !connected && !_showingCached)
+              const Expanded(child: _DisconnectedEmpty())
+            else if (_destinations.isEmpty)
+              Expanded(child: _pullDownDismiss(const _NoDestinationsEmpty()))
+            else
+              Expanded(child: _pullDownDismiss(_destinationList(connected))),
+          ],
+        ),
+        Selector<ScooterService, ({String? pendingName, bool isNavigating})>(
+          selector: (_, s) => (
+            pendingName: s.pendingNavigation?.name,
+            isNavigating: s.vehicle.navigationActive == true,
+          ),
+          builder: (context, state, _) {
+            if (state.pendingName == null && !state.isNavigating) return const SizedBox.shrink();
+            return Positioned(
+              bottom: MediaQuery.of(context).viewInsets.bottom + 32,
+              left: 16,
+              right: 16,
+              child: _navigationStatusCard(
+                isNavigating: state.isNavigating,
+                pendingName: state.pendingName,
+              ),
+            );
+          },
+        ),
+      ],
+    );
+
+    if (widget.embedded) {
+      return Material(
+        color: Theme.of(context).scaffoldBackgroundColor,
+        child: SafeArea(
+          top: false,
+          child: Column(
+            children: [
+              const SizedBox(height: 8),
+              Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 4, 8, 0),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        FlutterI18n.translate(context, "nav_title"),
+                        style: Theme.of(context).textTheme.headlineSmall,
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                      onPressed: () => Navigator.of(context).pop(),
+                      icon: const Icon(Icons.close),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(child: content),
+            ],
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(
@@ -530,52 +639,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
               ),
             )
           : null,
-      body: Stack(
-        children: [
-          Column(
-            children: [
-              if (_osmConsent) _searchField(),
-              const SizedBox(height: 8),
-              if (_loading && _initialLoad)
-                const Expanded(child: _DestinationsLoading())
-              else if (_destinations.isEmpty && !connected && !_showingCached)
-                const Expanded(child: _DisconnectedEmpty())
-              else if (_destinations.isEmpty)
-                Expanded(
-                  child: RefreshIndicator(
-                    onRefresh: _fetchDestinations,
-                    child: const _NoDestinationsEmpty(),
-                  ),
-                )
-              else
-                Expanded(
-                  child: RefreshIndicator(
-                    onRefresh: _fetchDestinations,
-                    child: _destinationList(connected),
-                  ),
-                ),
-            ],
-          ),
-          Selector<ScooterService, ({String? pendingName, bool isNavigating})>(
-            selector: (_, s) => (
-              pendingName: s.pendingNavigation?.name,
-              isNavigating: s.vehicle.navigationActive == true,
-            ),
-            builder: (context, state, _) {
-              if (state.pendingName == null && !state.isNavigating) return const SizedBox.shrink();
-              return Positioned(
-                bottom: MediaQuery.of(context).viewInsets.bottom + 32,
-                left: 16,
-                right: 16,
-                child: _navigationStatusCard(
-                  isNavigating: state.isNavigating,
-                  pendingName: state.pendingName,
-                ),
-              );
-            },
-          ),
-        ],
-      ),
+      body: content,
     );
   }
 
@@ -614,6 +678,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
   Widget _destinationList(bool connected) {
     final regularDests = _destinations.where((d) => d.type == null).toList();
     return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 40),
       itemCount: regularDests.length + 1,
       itemBuilder: (context, index) {
@@ -870,6 +935,7 @@ class _NoDestinationsEmpty extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
       children: [
         const SizedBox(height: 120),
         Center(

--- a/lib/navigation_screen.dart
+++ b/lib/navigation_screen.dart
@@ -553,7 +553,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
             if (_loading && _initialLoad)
               const Expanded(child: _DestinationsLoading())
             else if (_destinations.isEmpty && !connected && !_showingCached)
-              const Expanded(child: _DisconnectedEmpty())
+              Expanded(child: _pullDownDismiss(const _DisconnectedEmpty()))
             else if (_destinations.isEmpty)
               Expanded(child: _pullDownDismiss(const _NoDestinationsEmpty()))
             else

--- a/lib/navigation_screen.dart
+++ b/lib/navigation_screen.dart
@@ -13,6 +13,7 @@ import '../service/photon_service.dart';
 import '../domain/nav_destination.dart';
 import '../domain/saved_scooter.dart';
 import '../geo_helper.dart';
+import '../helper_widgets/header.dart';
 import '../scooter_service.dart';
 import '../service/ble_commands.dart';
 
@@ -581,42 +582,35 @@ class _NavigationScreenState extends State<NavigationScreen> {
     );
 
     if (widget.embedded) {
-      return Material(
-        color: Theme.of(context).scaffoldBackgroundColor,
-        child: SafeArea(
-          top: false,
-          child: Column(
-            children: [
-              const SizedBox(height: 8),
-              Container(
-                width: 36,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.outlineVariant,
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 4, 8, 0),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        FlutterI18n.translate(context, "nav_title"),
-                        style: Theme.of(context).textTheme.headlineSmall,
-                      ),
+      return SafeArea(
+        top: false,
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Center(
+                    child: Header(
+                      FlutterI18n.translate(context, "nav_title"),
+                      padding: const EdgeInsets.fromLTRB(48, 8, 48, 16),
                     ),
-                    IconButton(
+                  ),
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: IconButton(
                       tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
                       onPressed: () => Navigator.of(context).pop(),
                       icon: const Icon(Icons.close),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-              Expanded(child: content),
-            ],
-          ),
+            ),
+            Expanded(child: content),
+          ],
         ),
       );
     }
@@ -909,21 +903,24 @@ class _DisconnectedEmpty extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Icon(Icons.bluetooth_disabled, size: 64, color: Colors.grey),
-          const SizedBox(height: 16),
-          Text(
-            FlutterI18n.translate(context, "nav_disconnected_title"),
-            style: const TextStyle(fontSize: 18, color: Colors.grey),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            FlutterI18n.translate(context, "nav_disconnected_subtitle"),
-            style: const TextStyle(color: Colors.grey),
-          ),
-        ],
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.bluetooth_disabled, size: 64, color: Colors.grey),
+            const SizedBox(height: 16),
+            Text(
+              FlutterI18n.translate(context, "nav_disconnected_title"),
+              style: const TextStyle(fontSize: 18, color: Colors.grey),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              FlutterI18n.translate(context, "nav_disconnected_subtitle"),
+              style: const TextStyle(color: Colors.grey),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/test/home_screen_navigation_test.dart
+++ b/test/home_screen_navigation_test.dart
@@ -112,12 +112,14 @@ void main() {
     await pumpHome(tester);
 
     final cue = find.bySemanticsLabel('Navigation');
-    expect(find.text('Navigation'), findsOneWidget);
+    expect(find.text('Swipe up for navigation'), findsOneWidget);
     expect(tester.getSize(cue).height, greaterThanOrEqualTo(48));
     expect(tester.getSize(cue).width, tester.getSize(find.byType(HomeScreen)).width);
     final chevron = find.byIcon(Icons.keyboard_arrow_up_rounded);
-    final hint = find.text('Navigation');
-    expect(tester.getBottomLeft(chevron).dy, lessThanOrEqualTo(tester.getTopLeft(hint).dy));
+    final hint = find.text('Swipe up for navigation');
+    expect(tester.getSize(find.byType(Badge)).height, 14);
+    expect(tester.getCenter(chevron).dy, lessThan(tester.getTopLeft(hint).dy));
+    expect(tester.getTopLeft(chevron).dy, greaterThan(tester.getBottomLeft(find.text('Hold to start')).dy + 12));
     expect(tester.getCenter(chevron).dx, closeTo(tester.getCenter(hint).dx, 1));
     expect(tester.widget<Badge>(find.byType(Badge)).isLabelVisible, isFalse);
 
@@ -156,7 +158,7 @@ void main() {
   for (final brightness in Brightness.values) {
     testWidgets('navigation drawer uses the action sheet style in ${brightness.name} mode', (tester) async {
       await pumpHome(tester, brightness: brightness);
-      await tester.tap(find.text('Navigation'));
+      await tester.tap(find.text('Swipe up for navigation'));
       await tester.pumpAndSettle();
 
       expect(tester.widget<NavigationScreen>(find.byType(NavigationScreen)).embedded, isTrue);
@@ -191,8 +193,8 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
     await pumpHome(tester, textScale: 2);
-    expect(find.text('Navigation'), findsOneWidget);
-    await tester.tap(find.text('Navigation'));
+    expect(find.text('Swipe up for navigation'), findsOneWidget);
+    await tester.tap(find.text('Swipe up for navigation'));
     await tester.pumpAndSettle();
     final title = find.descendant(of: find.byType(NavigationScreen), matching: find.text('Navigation'));
     expect(tester.getRect(title).right, lessThan(tester.getRect(find.byTooltip('Close')).left));
@@ -236,10 +238,10 @@ void main() {
 
   testWidgets('deliberate swipe still opens navigation but a short drag does not', (tester) async {
     await pumpHome(tester);
-    await tester.drag(find.text('Navigation'), const Offset(0, -35));
+    await tester.drag(find.text('Swipe up for navigation'), const Offset(0, -35));
     await tester.pumpAndSettle();
     expect(find.byType(NavigationScreen), findsNothing);
-    await tester.drag(find.text('Navigation'), const Offset(0, -160));
+    await tester.drag(find.text('Swipe up for navigation'), const Offset(0, -160));
     await tester.pumpAndSettle();
     expect(find.byType(NavigationScreen), findsOneWidget);
     await tester.pumpWidget(const SizedBox.shrink());

--- a/test/home_screen_navigation_test.dart
+++ b/test/home_screen_navigation_test.dart
@@ -1,0 +1,231 @@
+import 'package:easy_dynamic_theme/easy_dynamic_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_i18n/flutter_i18n.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+// ignore: depend_on_referenced_packages
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:unustasis/domain/nav_destination.dart';
+import 'package:unustasis/domain/saved_scooter.dart';
+import 'package:unustasis/home_screen.dart';
+import 'package:unustasis/navigation_screen.dart';
+import 'package:unustasis/scooter_service.dart';
+import 'package:unustasis/state/battery_state.dart';
+import 'package:unustasis/state/scooter_identity.dart';
+import 'package:unustasis/state/vehicle_status.dart';
+
+// No ScooterService constructor, Bluetooth, storage, or background tasks run.
+class _NavigationService extends ChangeNotifier implements ScooterService {
+  @override
+  final identity = ScooterIdentity()..isLibrescoot = true;
+  @override
+  final vehicle = VehicleStatus();
+  @override
+  final battery = BatteryState();
+  @override
+  bool get connected => false;
+  @override
+  bool get scanning => false;
+  @override
+  NavDestination? pendingNavigation;
+  @override
+  Future<SavedScooter?> getMostRecentScooter() async => null;
+
+  void updateNavigation({bool? active, NavDestination? pending}) {
+    vehicle.navigationActive = active;
+    pendingNavigation = pending;
+    notifyListeners();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+final class _Preferences extends SharedPreferencesAsyncPlatform {
+  @override
+  Future<bool?> getBool(String key, SharedPreferencesOptions options) async => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late _NavigationService service;
+
+  setUp(() {
+    service = _NavigationService();
+    SharedPreferences.setMockInitialValues({});
+    final previousPreferences = SharedPreferencesAsyncPlatform.instance;
+    SharedPreferencesAsyncPlatform.instance = _Preferences();
+    addTearDown(() => SharedPreferencesAsyncPlatform.instance = previousPreferences);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('flutter.baseflow.com/geolocator'),
+      (call) async => call.method == 'isLocationServiceEnabled' ? false : null,
+    );
+  });
+
+  tearDown(() {
+    service.dispose();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(const MethodChannel('flutter.baseflow.com/geolocator'), null);
+  });
+
+  Future<void> pumpHome(
+    WidgetTester tester, {
+    Brightness brightness = Brightness.light,
+    Widget home = const HomeScreen(forceOpen: true),
+    double textScale = 1,
+  }) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ScooterService>.value(
+        value: service,
+        child: EasyDynamicThemeWidget(
+          initialThemeMode: brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+          child: MaterialApp(
+            theme: ThemeData(brightness: brightness),
+            localizationsDelegates: [
+              FlutterI18nDelegate(
+                translationLoader: FileTranslationLoader(
+                  forcedLocale: const Locale('en'),
+                  basePath: 'assets/i18n',
+                ),
+              ),
+            ],
+            builder: (context, child) => MediaQuery(
+              data: MediaQuery.of(context).copyWith(textScaler: TextScaler.linear(textScale)),
+              child: child!,
+            ),
+            home: home,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('navigation cue labels its action and reacts to pending and active navigation', (tester) async {
+    final semantics = tester.ensureSemantics();
+    await pumpHome(tester);
+
+    final cue = find.bySemanticsLabel('Navigation');
+    expect(find.text('Navigation'), findsOneWidget);
+    expect(tester.getSize(cue).height, greaterThanOrEqualTo(48));
+    expect(tester.widget<Badge>(find.byType(Badge)).isLabelVisible, isFalse);
+
+    // A queued destination without a display name must still show the dot.
+    service.updateNavigation(pending: NavDestination(location: const LatLng(52, 13)));
+    await tester.pump();
+    expect(tester.widget<Badge>(find.byType(Badge)).isLabelVisible, isTrue);
+    expect(
+        tester.getSemantics(cue),
+        matchesSemantics(
+          label: 'Navigation',
+          value: 'Pending navigation',
+          isButton: true,
+          hasTapAction: true,
+        ));
+
+    service.updateNavigation(active: true);
+    await tester.pump();
+    expect(tester.widget<Badge>(find.byType(Badge)).isLabelVisible, isTrue);
+    expect(
+        tester.getSemantics(cue),
+        matchesSemantics(
+          label: 'Navigation',
+          value: 'Navigation is active',
+          isButton: true,
+          hasTapAction: true,
+        ));
+
+    service.updateNavigation(active: false);
+    await tester.pump();
+    expect(tester.widget<Badge>(find.byType(Badge)).isLabelVisible, isFalse);
+    semantics.dispose();
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  for (final brightness in Brightness.values) {
+    testWidgets('navigation drawer uses the action sheet style in ${brightness.name} mode', (tester) async {
+      await pumpHome(tester, brightness: brightness);
+      await tester.tap(find.text('Navigation'));
+      await tester.pumpAndSettle();
+
+      expect(tester.widget<NavigationScreen>(find.byType(NavigationScreen)).embedded, isTrue);
+      final sheet = find.byType(BottomSheet);
+      expect(tester.widget<BottomSheet>(sheet).showDragHandle, isTrue);
+      final surface =
+          tester.widget<Material>(find.descendant(of: sheet, matching: find.byType(Material)).first);
+      expect(
+          surface.shape,
+          const RoundedRectangleBorder(
+            borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+          ));
+      expect(surface.clipBehavior, Clip.antiAlias);
+      expect(surface.color, Theme.of(tester.element(sheet)).colorScheme.surfaceContainerLow);
+      expect(tester.getSize(sheet).height, closeTo(600 * 0.9, 1));
+      final title = find.descendant(of: find.byType(NavigationScreen), matching: find.text('Navigation'));
+      expect(tester.getCenter(title).dx, closeTo(tester.getCenter(sheet).dx, 1));
+      final close = find.byTooltip('Close');
+      expect(tester.getRect(title).right, lessThan(tester.getRect(close).left));
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(close);
+      await tester.pumpAndSettle();
+      expect(find.byType(NavigationScreen), findsNothing);
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+  }
+
+  testWidgets('navigation cue and drawer title fit a narrow screen with larger text', (tester) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await pumpHome(tester, textScale: 2);
+    expect(find.text('Navigation'), findsOneWidget);
+    await tester.tap(find.text('Navigation'));
+    await tester.pumpAndSettle();
+    final title = find.descendant(of: find.byType(NavigationScreen), matching: find.text('Navigation'));
+    expect(tester.getRect(title).right, lessThan(tester.getRect(find.byTooltip('Close')).left));
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('full-screen navigation retains its app bar and back navigation', (tester) async {
+    await pumpHome(tester, home: Builder(builder: (context) {
+      return Scaffold(
+        body: TextButton(
+          onPressed: () => Navigator.of(context).push(MaterialPageRoute<void>(
+            builder: (_) => const NavigationScreen(),
+          )),
+          child: const Text('Open full-screen'),
+        ),
+      );
+    }));
+    await tester.tap(find.text('Open full-screen'));
+    await tester.pumpAndSettle();
+    expect(tester.widget<NavigationScreen>(find.byType(NavigationScreen)).embedded, isFalse);
+    expect(find.byType(AppBar), findsOneWidget);
+    expect(find.byType(BottomSheet), findsNothing);
+    expect(find.text('Navigation'), findsOneWidget);
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+    expect(find.byType(NavigationScreen), findsNothing);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('deliberate swipe still opens navigation but a short drag does not', (tester) async {
+    await pumpHome(tester);
+    await tester.drag(find.text('Navigation'), const Offset(0, -35));
+    await tester.pumpAndSettle();
+    expect(find.byType(NavigationScreen), findsNothing);
+    await tester.drag(find.text('Navigation'), const Offset(0, -160));
+    await tester.pumpAndSettle();
+    expect(find.byType(NavigationScreen), findsOneWidget);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}

--- a/test/home_screen_navigation_test.dart
+++ b/test/home_screen_navigation_test.dart
@@ -114,6 +114,11 @@ void main() {
     final cue = find.bySemanticsLabel('Navigation');
     expect(find.text('Navigation'), findsOneWidget);
     expect(tester.getSize(cue).height, greaterThanOrEqualTo(48));
+    expect(tester.getSize(cue).width, tester.getSize(find.byType(HomeScreen)).width);
+    final chevron = find.byIcon(Icons.keyboard_arrow_up_rounded);
+    final hint = find.text('Navigation');
+    expect(tester.getBottomLeft(chevron).dy, lessThanOrEqualTo(tester.getTopLeft(hint).dy));
+    expect(tester.getCenter(chevron).dx, closeTo(tester.getCenter(hint).dx, 1));
     expect(tester.widget<Badge>(find.byType(Badge)).isLabelVisible, isFalse);
 
     // A queued destination without a display name must still show the dot.

--- a/test/home_screen_navigation_test.dart
+++ b/test/home_screen_navigation_test.dart
@@ -192,6 +192,17 @@ void main() {
     final title = find.descendant(of: find.byType(NavigationScreen), matching: find.text('Navigation'));
     expect(tester.getRect(title).right, lessThan(tester.getRect(find.byTooltip('Close')).left));
     expect(tester.takeException(), isNull);
+    final scrollable = find.descendant(of: find.byType(NavigationScreen), matching: find.byType(Scrollable)).first;
+    final position = tester.state<ScrollableState>(scrollable).position;
+    expect(position.maxScrollExtent, greaterThan(0));
+    await tester.drag(scrollable, const Offset(0, -80));
+    await tester.pumpAndSettle();
+    expect(position.pixels, greaterThan(0));
+    position.jumpTo(0);
+    await tester.pump();
+    await tester.drag(scrollable, const Offset(0, 180));
+    await tester.pumpAndSettle();
+    expect(find.byType(NavigationScreen), findsNothing);
     await tester.pumpWidget(const SizedBox.shrink());
   });
 


### PR DESCRIPTION
## Summary
- replace the dangling Navigation action on the scooter visual with a bottom pull-up cue
- open Navigation in a 90 percent-height embedded sheet by tap or deliberate upward swipe
- require sufficient swipe distance or velocity to avoid accidental activation
- allow pulling down at the top of the destination list to dismiss the sheet
- keep the full-screen Navigation route available for existing callers
- update empty-state copy now that pull-down dismisses instead of refreshing

## Dependency
This PR is based on #167 because it addresses the dashboard layout on that branch.

## Validation
- `flutter analyze`
- `flutter test` (93 tests)
- locale JSON validation
- `git diff --check`